### PR TITLE
Fix empty extra data field with RHEED collection alignment

### DIFF
--- a/src/atomicds/results/rheed_image.py
+++ b/src/atomicds/results/rheed_image.py
@@ -377,7 +377,9 @@ class RHEEDImageResult(MSONable):
                 x,
                 new_df["mask_height"].iloc[0],  # type: ignore  # noqa: PGH003
                 new_df["mask_width"].iloc[0],  # type: ignore  # noqa: PGH003
-            )["counts"]
+            )[
+                "counts"
+            ]
 
             new_df = new_df.groupby("node_id").agg(agg_dict).reset_index(drop=True)
 


### PR DESCRIPTION
Fixes alignment with the `RheedImageCollection` data when `extra_data` is set to `None`