### PR TITLE
Change point information for growths

### DIFF
--- a/examples/changepoints.ipynb
+++ b/examples/changepoints.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Changepoint Detection\n",
+    "This short notebook shows how to pull changepoint detection records from the Atomscale API using `client.get_changepoints()`. Changepoints are time-bounded regions where an automated detector flagged a meaningful shift in one of the analyzed properties of a data item."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install atomscale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### API Client Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from atomscale import Client\n",
+    "from atomscale.results import ChangepointResult\n",
+    "\n",
+    "api_key = \"YOUR_API_KEY_HERE\"\n",
+    "client = Client(api_key=api_key)\n",
+    "\n",
+    "# Use a data ID from your catalogue. Search or grab one from the web interface.\n",
+    "data_id = \"YOUR_DATA_ID_HERE\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fetching Changepoints\n",
+    "Call `get_changepoints` with one or more `data_ids` to get back a pandas `DataFrame` of detected changepoints. With default arguments it returns the most recent intensity-profile detection run, filtered to the critical severity tier — a good starting point for most users."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "changepoints = client.get_changepoints(data_ids=data_id)\n",
+    "changepoints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each row is a single changepoint. The columns are:\n",
+    "```\n",
+    "['id', 'data_id', 'data_modality', 'property_name', 'severity', 'score',\n",
+    " 'window_start_elapsed', 'window_end_elapsed', 'detection_method', 'detail', 'label']\n",
+    "```\n",
+    "- `score` is a normalized magnitude in `[0, 1]` — higher means stronger signal.\n",
+    "- `window_start_elapsed` / `window_end_elapsed` are seconds from the start of the source time series, so you can line changepoints up against timeseries data pulled via `client.get()`.\n",
+    "- `detail` holds method-specific metadata (e.g. RMS error, comparison window size).\n",
+    "- `label` is the applied category label if one has been set, otherwise `None`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtering Options\n",
+    "The defaults keep the view focused, but all three filter arguments can be adjusted:\n",
+    "\n",
+    "- `detection_method` — `\"forecasting\"`, `\"clustering\"`, `\"intensity_profile\"`, or `None` for all methods. Defaults to `\"intensity_profile\"`.\n",
+    "- `severity` — `\"info\"`, `\"warning\"`, `\"critical\"`, or `None` for all levels. Defaults to `\"critical\"`.\n",
+    "- `latest_only` — when `True` (default), only anomalies from the most recently completed run per `(data_id, detection_method)` are returned. Set to `False` to include every historical run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Everything the detector flagged, no filters applied.\n",
+    "all_changepoints = client.get_changepoints(\n",
+    "    data_ids=data_id,\n",
+    "    detection_method=None,\n",
+    "    severity=None,\n",
+    ")\n",
+    "all_changepoints[[\"detection_method\", \"severity\", \"score\", \"property_name\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All historical runs for this data_id, not just the latest.\n",
+    "history = client.get_changepoints(\n",
+    "    data_ids=data_id,\n",
+    "    detection_method=None,\n",
+    "    severity=None,\n",
+    "    latest_only=False,\n",
+    ")\n",
+    "print(f\"latest run only: {len(all_changepoints)} rows\")\n",
+    "print(f\"all historical runs: {len(history)} rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Result Objects\n",
+    "Pass `as_dataframe=False` to get a list of `ChangepointResult` objects instead of a DataFrame. Useful when you want to iterate and work with the records programmatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = client.get_changepoints(data_ids=data_id, as_dataframe=False)\n",
+    "\n",
+    "for cp in results[:5]:\n",
+    "    window = f\"[{cp.window_start_elapsed:.1f}s \\u2192 {cp.window_end_elapsed:.1f}s]\"\n",
+    "    print(f\"{cp.severity:>8}  score={cp.score:.3f}  {window}  {cp.property_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Batch Over Multiple Data IDs\n",
+    "`data_ids` accepts a list; requests are chunked under the hood so you can pass an arbitrary number of IDs in a single call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use a search to pull a batch of data IDs, then fetch changepoints across all of them.\n",
+    "search_results = client.search(data_type=\"rheed_stationary\", status=\"success\")\n",
+    "data_ids = search_results[\"Data ID\"].to_list()\n",
+    "\n",
+    "batch = client.get_changepoints(data_ids=data_ids)\n",
+    "batch.groupby(\"data_id\").size().sort_values(ascending=False).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more information on other data from the API or other example use see notebooks in the code repository (https://github.com/atomic-data-sciences/api-client) and the documentation (https://atomic-data-sciences.github.io/api-client/)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/atomscale/client.py
+++ b/src/atomscale/client.py
@@ -328,15 +328,13 @@ class Client(BaseClient):
             data_ids[i : i + chunk_size] for i in range(0, len(data_ids), chunk_size)
         ]
 
-        # Backend endpoint and response key are named "anomalies"; SDK surfaces this
-        # as "changepoints" for user-facing consistency.
         for chunk in chunks:
             payload: dict | None = self._get(  # type: ignore[assignment]
-                sub_url="anomalies/",
+                sub_url="changepoints/",
                 params={"data_ids": chunk, "latest_only": latest_only},
             )
             if payload:
-                records.extend(payload.get("anomalies", []))
+                records.extend(payload.get("changepoints", []))
 
         if detection_method is not None:
             records = [

--- a/src/atomscale/client.py
+++ b/src/atomscale/client.py
@@ -15,6 +15,7 @@ from pandas import DataFrame
 from atomscale.core import BaseClient, ClientError, _FileSlice
 from atomscale.core.utils import _make_progress, normalize_path
 from atomscale.results import (
+    ChangepointResult,
     PhotoluminescenceResult,
     RamanResult,
     RHEEDImageResult,
@@ -288,6 +289,80 @@ class Client(BaseClient):
                 progress,
                 progress_description="Obtaining data results",
             )
+
+    def get_changepoints(
+        self,
+        data_ids: str | list[str],
+        latest_only: bool = True,
+        detection_method: (
+            Literal["forecasting", "clustering", "intensity_profile"] | None
+        ) = "intensity_profile",
+        severity: Literal["info", "warning", "critical"] | None = "critical",
+        as_dataframe: bool = True,
+    ) -> DataFrame | list[ChangepointResult]:
+        """Get changepoint detection records for one or more data IDs.
+
+        Args:
+            data_ids (str | list[str]): Data ID or list of data IDs from the data catalogue.
+            latest_only (bool): If True (default), only return changepoints from the most
+                recently completed detection run for each (data_id, detection_method) pair.
+                If False, return all changepoints from every historical run.
+            detection_method (str | None): Filter to a single detection method. One of
+                "forecasting", "clustering", "intensity_profile". Defaults to "intensity_profile".
+                Pass None to include all detection methods.
+            severity (str | None): Filter to a single severity level. One of "info",
+                "warning", "critical". Defaults to "critical". Pass None to include all
+                severities.
+            as_dataframe (bool): If True (default) return a pandas DataFrame. If False
+                return a list of ChangepointResult objects.
+
+        Returns:
+            DataFrame | list[ChangepointResult]: Changepoint records matching the filters.
+        """
+        if isinstance(data_ids, str):
+            data_ids = [data_ids]
+
+        records: list[dict] = []
+        chunk_size = 100
+        chunks = [
+            data_ids[i : i + chunk_size] for i in range(0, len(data_ids), chunk_size)
+        ]
+
+        # Backend endpoint and response key are named "anomalies"; SDK surfaces this
+        # as "changepoints" for user-facing consistency.
+        for chunk in chunks:
+            payload: dict | None = self._get(  # type: ignore[assignment]
+                sub_url="anomalies/",
+                params={"data_ids": chunk, "latest_only": latest_only},
+            )
+            if payload:
+                records.extend(payload.get("anomalies", []))
+
+        if detection_method is not None:
+            records = [
+                r for r in records if r.get("detection_method") == detection_method
+            ]
+        if severity is not None:
+            records = [r for r in records if r.get("severity") == severity]
+
+        if as_dataframe:
+            # Keep only the label itself; drop label provenance/metadata fields.
+            _drop = {
+                "label_category",
+                "label_notes",
+                "label_source",
+                "label_confidence",
+                "labeled_at",
+                "labeled_by_user_id",
+                "similar_neighbor_ids",
+            }
+            rows = [
+                {**{k: v for k, v in r.items() if k not in _drop},
+                 "label": r.get("label_category")}
+                for r in records
+            ]
+            return DataFrame(rows)
+        return [ChangepointResult.from_api(r) for r in records]
 
     def list_physical_samples(self) -> DataFrame:
         """List physical samples available to the user."""

--- a/src/atomscale/client.py
+++ b/src/atomscale/client.py
@@ -357,8 +357,10 @@ class Client(BaseClient):
                 "similar_neighbor_ids",
             }
             rows = [
-                {**{k: v for k, v in r.items() if k not in _drop},
-                 "label": r.get("label_category")}
+                {
+                    **{k: v for k, v in r.items() if k not in _drop},
+                    "label": r.get("label_category"),
+                }
                 for r in records
             ]
             return DataFrame(rows)

--- a/src/atomscale/results/__init__.py
+++ b/src/atomscale/results/__init__.py
@@ -1,3 +1,4 @@
+from .changepoint import ChangepointResult
 from .group import PhysicalSampleResult, ProjectResult
 from .metrology import MetrologyResult
 from .optical import OpticalResult
@@ -11,6 +12,7 @@ from .xps import XPSResult
 from .xrd import XRDResult
 
 __all__ = [
+    "ChangepointResult",
     "MetrologyResult",
     "OpticalResult",
     "PhotoluminescenceResult",

--- a/src/atomscale/results/changepoint.py
+++ b/src/atomscale/results/changepoint.py
@@ -1,0 +1,67 @@
+"""Result object for changepoint detection records."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from monty.json import MSONable
+
+
+class ChangepointResult(MSONable):
+    def __init__(
+        self,
+        id: UUID | str,
+        data_id: UUID | str,
+        data_modality: str,
+        property_name: str,
+        severity: str,
+        score: float,
+        window_start_elapsed: float,
+        window_end_elapsed: float,
+        detection_method: str,
+        detail: dict[str, Any],
+        label: str | None = None,
+    ):
+        """Changepoint detection result
+
+        Args:
+            id (UUID | str): Unique ID of the changepoint record.
+            data_id (UUID | str): Data ID in the catalogue this changepoint was detected on.
+            data_modality (str): Source/workflow value the changepoint came from (e.g. "rheed_stationary").
+            property_name (str): Property/channel on which the changepoint was detected.
+            severity (str): One of "info", "warning", "critical".
+            score (float): Normalized changepoint score in [0, 1].
+            window_start_elapsed (float): Start of the changepoint window, seconds from timeseries start.
+            window_end_elapsed (float): End of the changepoint window, seconds from timeseries start.
+            detection_method (str): One of "forecasting", "clustering", "intensity_profile".
+            detail (dict): Method-specific metadata.
+            label (str | None): Applied category label, if any.
+        """
+        self.id = id
+        self.data_id = data_id
+        self.data_modality = data_modality
+        self.property_name = property_name
+        self.severity = severity
+        self.score = score
+        self.window_start_elapsed = window_start_elapsed
+        self.window_end_elapsed = window_end_elapsed
+        self.detection_method = detection_method
+        self.detail = detail
+        self.label = label
+
+    @classmethod
+    def from_api(cls, payload: dict[str, Any]) -> ChangepointResult:
+        return cls(
+            id=payload["id"],
+            data_id=payload["data_id"],
+            data_modality=payload["data_modality"],
+            property_name=payload["property_name"],
+            severity=payload["severity"],
+            score=payload["score"],
+            window_start_elapsed=payload["window_start_elapsed"],
+            window_end_elapsed=payload["window_end_elapsed"],
+            detection_method=payload["detection_method"],
+            detail=payload.get("detail") or {},
+            label=payload.get("label_category"),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,5 +27,6 @@ class ResultIDs:
     metrology = ""
     photoluminescence = ""
     raman = ""
+    changepoint = ""
     similarity_workflow = "rheed_stationary"
     similarity_source_id = "bb3494b1-b5fb-4f3e-ac50-e4024f8aacf5"

--- a/tests/test_changepoint.py
+++ b/tests/test_changepoint.py
@@ -1,0 +1,51 @@
+import pytest
+from atomscale import Client
+from atomscale.results import ChangepointResult
+from pandas import DataFrame
+
+from .conftest import ResultIDs
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def result(client: Client):
+    if not ResultIDs.changepoint:
+        pytest.skip("No changepoint data available")
+
+    return client.get_changepoints(data_ids=ResultIDs.changepoint)
+
+
+def test_data_structure(result: DataFrame):
+    assert isinstance(result, DataFrame)
+    expected_cols = {
+        "id",
+        "data_id",
+        "data_modality",
+        "property_name",
+        "severity",
+        "score",
+        "window_start_elapsed",
+        "window_end_elapsed",
+        "detection_method",
+    }
+    if result.empty:
+        return
+    assert expected_cols.issubset(set(result.columns))
+    assert (result["detection_method"] == "intensity_profile").all()
+    assert (result["severity"] == "critical").all()
+
+
+def test_as_objects(client: Client):
+    if not ResultIDs.changepoint:
+        pytest.skip("No changepoint data available")
+
+    results = client.get_changepoints(
+        data_ids=ResultIDs.changepoint, as_dataframe=False
+    )
+    assert isinstance(results, list)
+    for cp in results:
+        assert isinstance(cp, ChangepointResult)


### PR DESCRIPTION
- Adds `Client.get_changepoints()` — fetches changepoint records from `/anomalies/`, returns a `DataFrame` (or `list[ChangepointResult]` with `as_dataframe=False`)               
- Defaults: `detection_method="intensity_profile"`, `severity="critical"`, `latest_only=True`; pass `None` / `False` to broaden                        
- New `ChangepointResult` class exported from `atomscale.results`                                                                                      
- Surfaces only the `label` itself — drops all label provenance fields                                                                                 
- Adds `tests/test_changepoint.py` and `examples/changepoints.ipynb`                                                                                   
- Backend endpoint is still dev-gated; returns empty in prod until that lifts 