### PR TITLE
Add tags parameter to stream initialization

### DIFF
--- a/src/atomscale/streaming/rheed_stream.pyi
+++ b/src/atomscale/streaming/rheed_stream.pyi
@@ -26,6 +26,7 @@ class RHEEDStreamer:
         stream_name: str | None = None,
         physical_sample: str | None = None,
         project_id: str | None = None,
+        tags: list[str] | None = None,
     ) -> str:
         """Initialize a new RHEED stream.
 
@@ -47,6 +48,10 @@ class RHEEDStreamer:
             project_id: UUID of the associated project. When provided along
                 with physical_sample, the project's tracking_physical_sample_id
                 is automatically updated to link the sample for growth monitoring.
+            tags: List of tag names or UUIDs to attach to the data item.
+                Names are matched case-insensitively against existing
+                organization tags; unknown names are created. UUIDs must
+                reference existing tags.
 
         Returns:
             The data_id for this stream.
@@ -100,6 +105,7 @@ class TimeseriesStreamer:
         synth_source_id: int | None = None,
         physical_sample: str | None = None,
         project_id: str | None = None,
+        tags: list[str] | None = None,
     ) -> str:
         """Initialize a new timeseries stream.
 
@@ -118,6 +124,10 @@ class TimeseriesStreamer:
             project_id: UUID of the associated project. When provided along with
                 physical_sample, the project's tracking_physical_sample_id is
                 automatically updated to link the sample for growth monitoring.
+            tags: List of tag names or UUIDs to attach to the data item.
+                Names are matched case-insensitively against existing
+                organization tags; unknown names are created. UUIDs must
+                reference existing tags.
 
         Returns:
             The data_id for this stream.

--- a/src/atomscale/streaming/src/initialize.rs
+++ b/src/atomscale/streaming/src/initialize.rs
@@ -223,3 +223,129 @@ pub async fn update_project_tracking_sample(
 
     Ok(())
 }
+
+#[derive(Deserialize, Debug)]
+struct TagSummary {
+    id: String,
+    name: String,
+}
+
+#[derive(Serialize)]
+struct CreateTagRequest<'a> {
+    name: &'a str,
+}
+
+#[derive(Deserialize, Debug)]
+struct CreateTagResponse {
+    id: String,
+}
+
+#[derive(Serialize)]
+struct AttachTagsRequest {
+    data_ids: Vec<String>,
+    tag_ids: Vec<String>,
+}
+
+/// Resolves tag inputs to tag IDs and attaches them to a data item.
+///
+/// For each input string:
+///   - If it looks like a UUID, looks up the tag by id (errors if not found).
+///   - Otherwise, finds an existing tag by case-insensitive name match, or
+///     creates a new tag using the input's exact casing.
+///
+/// Inputs are trimmed; empty entries are dropped; remaining entries are
+/// deduplicated case-insensitively (preserving first-seen casing) before
+/// resolution. If no inputs remain, no requests are made and an empty
+/// vector is returned.
+///
+/// On success, issues a single bulk `POST /tags/data-items/` to attach all
+/// resolved tag IDs to the given `data_id`.
+pub async fn ensure_tags_attached(
+    client: &Client,
+    base_endpoint: &str,
+    api_key: &str,
+    data_id: &str,
+    tag_inputs: &[String],
+) -> Result<Vec<String>> {
+    // Trim, drop empties, dedupe case-insensitively (preserve first-seen casing).
+    let mut seen_lower: Vec<String> = Vec::new();
+    let mut cleaned: Vec<String> = Vec::new();
+    for raw in tag_inputs {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if seen_lower.iter().any(|s| s == &lower) {
+            continue;
+        }
+        seen_lower.push(lower);
+        cleaned.push(trimmed.to_string());
+    }
+    if cleaned.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let list_url = format!("{base_endpoint}/tags/");
+    let existing_tags: Vec<TagSummary> = client
+        .get(&list_url)
+        .header("X-API-KEY", api_key)
+        .send()
+        .await
+        .context("failed to request tags")?
+        .error_for_status()
+        .context("tag list returned error status")?
+        .json()
+        .await
+        .context("failed to deserialize tag list")?;
+
+    let mut tag_ids: Vec<String> = Vec::with_capacity(cleaned.len());
+    for input in &cleaned {
+        let id = if looks_like_uuid(input) {
+            existing_tags
+                .iter()
+                .find(|t| t.id == *input)
+                .map(|t| t.id.clone())
+                .ok_or_else(|| anyhow::anyhow!("tag with id '{}' not found", input))?
+        } else if let Some(tag) = existing_tags
+            .iter()
+            .find(|t| t.name.eq_ignore_ascii_case(input))
+        {
+            tag.id.clone()
+        } else {
+            let body = CreateTagRequest { name: input };
+            let created: CreateTagResponse = client
+                .post(&list_url)
+                .header("X-API-KEY", api_key)
+                .json(&body)
+                .send()
+                .await
+                .context("failed to create tag")?
+                .error_for_status()
+                .context("tag creation returned error status")?
+                .json()
+                .await
+                .context("failed to deserialize tag creation response")?;
+            created.id
+        };
+        tag_ids.push(id);
+    }
+
+    let attach_url = format!("{base_endpoint}/tags/data-items/");
+    let attach_body = AttachTagsRequest {
+        data_ids: vec![data_id.to_string()],
+        tag_ids: tag_ids.clone(),
+    };
+
+    client
+        .post(&attach_url)
+        .header("X-API-KEY", api_key)
+        .json(&attach_body)
+        .send()
+        .await
+        .context("failed to attach tags to data item")?
+        .error_for_status()
+        .context("tag attach returned error status")?;
+
+    Ok(tag_ids)
+}

--- a/src/atomscale/streaming/src/lib.rs
+++ b/src/atomscale/streaming/src/lib.rs
@@ -17,8 +17,8 @@ use timeseries::TimeseriesStreamer;
 
 mod initialize;
 use initialize::{
-    ensure_physical_sample_link, post_for_initialization, update_project_tracking_sample,
-    RHEEDStreamSettings,
+    ensure_physical_sample_link, ensure_tags_attached, post_for_initialization,
+    update_project_tracking_sample, RHEEDStreamSettings,
 };
 
 mod upload;
@@ -138,15 +138,18 @@ impl RHEEDStreamer {
     ///     project_id (Optional[str]): UUID of a project to associate with the stream. When provided along with
     ///         `physical_sample`, the project's `tracking_physical_sample_id` configuration is automatically updated
     ///         to link the physical sample to the project for growth monitoring.
+    ///     tags (Optional[List[str]]): List of tag names or UUIDs to attach to the data item. Names are matched
+    ///         case-insensitively against existing org tags; unknown names are created. UUIDs must reference
+    ///         existing tags.
     ///
     /// Returns:
     ///     str: The created `data_id` for this stream.
     ///
     /// Raises:
     ///     RuntimeError: If the initialization POST fails.
-    #[pyo3(signature = (fps, rotations_per_min, chunk_size, stream_name=None, physical_sample=None, project_id=None))]
+    #[pyo3(signature = (fps, rotations_per_min, chunk_size, stream_name=None, physical_sample=None, project_id=None, tags=None))]
     #[pyo3(
-        text_signature = "(fps, rotations_per_min, chunk_size, stream_name=None, physical_sample=None, project_id=None)"
+        text_signature = "(fps, rotations_per_min, chunk_size, stream_name=None, physical_sample=None, project_id=None, tags=None)"
     )]
     fn initialize(
         &mut self,
@@ -156,6 +159,7 @@ impl RHEEDStreamer {
         stream_name: Option<String>,
         physical_sample: Option<String>,
         project_id: Option<String>,
+        tags: Option<Vec<String>>,
     ) -> PyResult<String> {
         // Guard: chunk_size must be >= ceil(2 * fps)
         let min_chunk = (2.0 * fps).ceil() as usize;
@@ -225,6 +229,21 @@ impl RHEEDStreamer {
                 );
                 self.rt
                     .block_on(update_project_fut)
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            }
+        }
+
+        if let Some(tag_inputs) = tags {
+            if !tag_inputs.is_empty() {
+                let tags_fut = ensure_tags_attached(
+                    &self.client,
+                    &base_endpoint,
+                    &self.api_key,
+                    &data_id,
+                    &tag_inputs,
+                );
+                self.rt
+                    .block_on(tags_fut)
                     .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
             }
         }

--- a/src/atomscale/streaming/src/timeseries.rs
+++ b/src/atomscale/streaming/src/timeseries.rs
@@ -9,7 +9,9 @@ use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
 use tracing::debug;
 
-use crate::initialize::{ensure_physical_sample_link, update_project_tracking_sample};
+use crate::initialize::{
+    ensure_physical_sample_link, ensure_tags_attached, update_project_tracking_sample,
+};
 use crate::utils::init_tracing_once;
 
 /// Request body for stream initialization.
@@ -133,15 +135,18 @@ impl TimeseriesStreamer {
     ///         provided along with `physical_sample`, the project's `tracking_physical_sample_id`
     ///         configuration is automatically updated to link the physical sample to the project
     ///         for growth monitoring.
+    ///     tags (Optional[List[str]]): List of tag names or UUIDs to attach to the data item. Names
+    ///         are matched case-insensitively against existing org tags; unknown names are created.
+    ///         UUIDs must reference existing tags.
     ///
     /// Returns:
     ///     str: The data_id for this stream.
     ///
     /// Raises:
     ///     RuntimeError: If the initialization request fails or instrument not found.
-    #[pyo3(signature = (stream_name=None, synth_source_id=None, physical_sample=None, project_id=None))]
+    #[pyo3(signature = (stream_name=None, synth_source_id=None, physical_sample=None, project_id=None, tags=None))]
     #[pyo3(
-        text_signature = "(stream_name=None, synth_source_id=None, physical_sample=None, project_id=None)"
+        text_signature = "(stream_name=None, synth_source_id=None, physical_sample=None, project_id=None, tags=None)"
     )]
     fn initialize(
         &self,
@@ -149,6 +154,7 @@ impl TimeseriesStreamer {
         synth_source_id: Option<i64>,
         physical_sample: Option<String>,
         project_id: Option<String>,
+        tags: Option<Vec<String>>,
     ) -> PyResult<String> {
         let physical_sample = physical_sample
             .map(|s| s.trim().to_string())
@@ -199,8 +205,8 @@ impl TimeseriesStreamer {
         };
 
         // Handle physical sample linking (same flow as RHEEDStreamer)
+        let base_endpoint = self.endpoint.clone();
         if let Some(sample_name) = physical_sample {
-            let base_endpoint = self.endpoint.clone();
             let physical_sample_fut = ensure_physical_sample_link(
                 &self.client,
                 &base_endpoint,
@@ -224,6 +230,21 @@ impl TimeseriesStreamer {
                 );
                 self.rt
                     .block_on(update_project_fut)
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            }
+        }
+
+        if let Some(tag_inputs) = tags {
+            if !tag_inputs.is_empty() {
+                let tags_fut = ensure_tags_attached(
+                    &self.client,
+                    &base_endpoint,
+                    &self.api_key,
+                    &data_id,
+                    &tag_inputs,
+                );
+                self.rt
+                    .block_on(tags_fut)
                     .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
             }
         }

--- a/tests/_mock_http_server.py
+++ b/tests/_mock_http_server.py
@@ -32,18 +32,29 @@ class CaptureHandler(BaseHTTPRequestHandler):
         routes = getattr(self.server, "routes", None)
 
         if routes:
-            # Routes mode: find matching route
+            # Routes mode: prefer method-keyed routes ("POST /tags/"), then
+            # fall back to path-only routes ("/tags/"). Insertion order wins
+            # within each group.
             response_data = None
-            for route_path, route_response in routes.items():
-                if path.startswith(route_path):
-                    response_data = route_response
-                    break
+            for route_key, route_response in routes.items():
+                if " " in route_key:
+                    route_method, route_path = route_key.split(" ", 1)
+                    if method == route_method and path.startswith(route_path):
+                        response_data = route_response
+                        break
+            if response_data is None:
+                for route_key, route_response in routes.items():
+                    if " " in route_key:
+                        continue
+                    if path.startswith(route_key):
+                        response_data = route_response
+                        break
 
             if response_data is None:
                 # Default response for unmatched routes
                 response_data = '""'
 
-            # Print request info for debugging
+            # Print request info for debugging / structured capture.
             print(f"REQUEST:{method}:{path}:{body.decode() if body else ''}", flush=True)
         else:
             # Simple mode: single response for all requests

--- a/tests/test_rheed_stream.py
+++ b/tests/test_rheed_stream.py
@@ -62,6 +62,37 @@ class MockServer:
                     break
         return self._captured_body
 
+    def get_captured_requests(self) -> list[dict]:
+        """Return list of {method, path, body} dicts from routes-mode logs.
+
+        Drains stdout up to and including the EOF that occurs when the server
+        process exits (after handling __max_requests__ requests). Safe to call
+        only once per server.
+        """
+        if self._proc is None:
+            return []
+        try:
+            stdout, _ = self._proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._proc.terminate()
+            stdout, _ = self._proc.communicate(timeout=5)
+        self._proc = None
+        captured: list[dict] = []
+        for line in stdout.splitlines():
+            if not line.startswith("REQUEST:"):
+                continue
+            # Format: REQUEST:METHOD:PATH:BODY (BODY may contain ':' from JSON)
+            parts = line[len("REQUEST:"):].split(":", 2)
+            if len(parts) != 3:
+                continue
+            method, path, body = parts
+            try:
+                body_obj = json.loads(body) if body else None
+            except json.JSONDecodeError:
+                body_obj = body
+            captured.append({"method": method, "path": path, "body": body_obj})
+        return captured
+
     def __enter__(self) -> "MockServer":
         self.start()
         return self
@@ -277,3 +308,238 @@ class TestRHEEDStreamerInitialize:
         )
 
         assert data_id == "test-data-id-999"
+
+    def test_initialize_accepts_tags_parameter(self):
+        """Verify initialize() signature includes the tags parameter."""
+        import inspect
+
+        from atomscale.streaming.rheed_stream import RHEEDStreamer
+
+        sig = inspect.signature(RHEEDStreamer.initialize)
+        assert "tags" in sig.parameters
+        assert sig.parameters["tags"].default is None
+
+    def test_initialize_skips_tag_endpoints_when_tags_none(self, mock_server_factory):
+        """Verify no /tags/ traffic when tags is None (single request)."""
+        from atomscale.streaming.rheed_stream import RHEEDStreamer
+
+        server = mock_server_factory('"data-id-no-tags"')
+
+        streamer = RHEEDStreamer(api_key="k", endpoint=server.endpoint)
+        data_id = streamer.initialize(fps=30.0, rotations_per_min=0.0, chunk_size=60)
+
+        assert data_id == "data-id-no-tags"
+        body = server.get_captured_body()
+        assert body is not None
+        assert "data_item_name" in body  # confirms only the init POST was captured
+
+    def test_initialize_skips_tag_endpoints_when_tags_empty(self, mock_server_factory):
+        """Empty list, all-whitespace entries → no tag traffic."""
+        from atomscale.streaming.rheed_stream import RHEEDStreamer
+
+        server = mock_server_factory('"data-id-empty-tags"')
+
+        streamer = RHEEDStreamer(api_key="k", endpoint=server.endpoint)
+        data_id = streamer.initialize(
+            fps=30.0,
+            rotations_per_min=0.0,
+            chunk_size=60,
+            tags=["", "  "],
+        )
+
+        assert data_id == "data-id-empty-tags"
+
+    def test_initialize_resolves_dedupes_and_creates_tags(self, mock_server_factory):
+        """End-to-end tag resolution: case-insensitive match, whitespace trim,
+        case-insensitive dedupe, find-or-create, and bulk attach payload.
+
+        Input tags: ["  growth  ", "GROWTH", "novel-tag", ""]
+        Existing org tags: [{name: "growth", id: G}]
+
+        Expected requests (4 total):
+        1. POST /rheed/stream/         → data_id
+        2. GET  /tags/                 → returns existing (only "growth")
+        3. POST /tags/                 → creates "novel-tag", returns its id
+        4. POST /tags/data-items/      → bulk attach with both ids
+        """
+        from atomscale.streaming.rheed_stream import RHEEDStreamer
+
+        existing_id = "11111111-1111-1111-1111-111111111111"
+        new_id = "33333333-3333-3333-3333-333333333333"
+
+        # Method-keyed routes let GET /tags/ return a list while POST /tags/
+        # returns the created-tag object. Path-only routes serve as fallbacks.
+        routes = json.dumps({
+            "__routes__": True,
+            "__max_requests__": 4,
+            "POST /tags/data-items/": '{"success": true, "associations_created": 2}',
+            "GET /tags/": json.dumps([{"id": existing_id, "name": "growth"}]),
+            "POST /tags/": json.dumps({"id": new_id, "name": "novel-tag"}),
+            "/rheed/stream/": '"data-id-mixed"',
+        })
+
+        server = mock_server_factory(routes)
+        streamer = RHEEDStreamer(api_key="k", endpoint=server.endpoint)
+
+        data_id = streamer.initialize(
+            fps=30.0,
+            rotations_per_min=0.0,
+            chunk_size=60,
+            tags=["  growth  ", "GROWTH", "novel-tag", ""],
+        )
+
+        assert data_id == "data-id-mixed"
+
+        requests = server.get_captured_requests()
+        # Filter to /tags/ traffic — the init POST is uninteresting here.
+        tag_reqs = [r for r in requests if r["path"].startswith("/tags/")]
+        # Exactly: one GET, one create-POST, one attach-POST. Dedup means the
+        # repeated "growth"/"GROWTH" entries did not produce extra creates.
+        methods_paths = [(r["method"], r["path"]) for r in tag_reqs]
+        assert methods_paths == [
+            ("GET", "/tags/"),
+            ("POST", "/tags/"),
+            ("POST", "/tags/data-items/"),
+        ], methods_paths
+
+        # POST /tags/ body uses the trimmed name (no surrounding spaces).
+        create_body = next(r["body"] for r in tag_reqs if r["method"] == "POST" and r["path"] == "/tags/")
+        assert create_body == {"name": "novel-tag"}
+
+        # POST /tags/data-items/ body has data_id + both resolved tag_ids in order.
+        attach_body = next(r["body"] for r in tag_reqs if r["path"] == "/tags/data-items/")
+        assert attach_body == {
+            "data_ids": ["data-id-mixed"],
+            "tag_ids": [existing_id, new_id],
+        }
+
+    def test_initialize_attaches_tags_with_physical_sample_and_project(
+        self, mock_server_factory
+    ):
+        """Tags can be combined with physical_sample + project_id in one call.
+
+        Expected requests (all using existing entities, so no creates):
+        1. POST /rheed/stream/
+        2. GET  /physical_samples/    → list with sample
+        3. POST /data_entries/physical_sample
+        4. GET  /projects/            → list with project config
+        5. POST /projects/{id}/configuration
+        6. GET  /tags/                → list with tag
+        7. POST /tags/data-items/
+        """
+        from atomscale.streaming.rheed_stream import RHEEDStreamer
+
+        project_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        sample_uuid = "660e8400-e29b-41d4-a716-446655440001"
+        tag_uuid = "770e8400-e29b-41d4-a716-446655440002"
+
+        routes = json.dumps({
+            "__routes__": True,
+            "__max_requests__": 7,
+            "/tags/data-items/": '{"success": true, "associations_created": 1}',
+            "/tags/": json.dumps([{"id": tag_uuid, "name": "growth"}]),
+            "/data_entries/physical_sample": '"OK"',
+            "/physical_samples/": json.dumps(
+                [{"id": sample_uuid, "name": "Test Sample"}]
+            ),
+            f"/projects/{project_uuid}/configuration": '"OK"',
+            "/projects/": json.dumps([{
+                "id": project_uuid,
+                "name": "Test Project",
+                "configuration": {"api_configuration": {}},
+            }]),
+            "/rheed/stream/": '"data-id-combined"',
+        })
+
+        server = mock_server_factory(routes)
+        streamer = RHEEDStreamer(api_key="k", endpoint=server.endpoint)
+
+        data_id = streamer.initialize(
+            fps=30.0,
+            rotations_per_min=0.0,
+            chunk_size=60,
+            physical_sample="Test Sample",
+            project_id=project_uuid,
+            tags=["growth"],
+        )
+
+        assert data_id == "data-id-combined"
+
+    def test_initialize_attaches_azimuth_tags(self, mock_server_factory):
+        """Primary use case: attach RHEED azimuth tags ("100", "210", "110").
+
+        The general resolver behavior (find-or-create, dedupe, whitespace) is
+        exercised in test_initialize_resolves_dedupes_and_creates_tags. This
+        test pins the concrete azimuth-tag scenario the feature was built for:
+        all three azimuth tags already exist in the org, and the streamer
+        attaches them in input order.
+        """
+        from atomscale.streaming.rheed_stream import RHEEDStreamer
+
+        id_100 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        id_210 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        id_110 = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+        routes = json.dumps({
+            "__routes__": True,
+            "__max_requests__": 3,
+            "POST /tags/data-items/": '{"success": true, "associations_created": 3}',
+            "GET /tags/": json.dumps([
+                {"id": id_100, "name": "100"},
+                {"id": id_210, "name": "210"},
+                {"id": id_110, "name": "110"},
+            ]),
+            "/rheed/stream/": '"data-id-azimuth"',
+        })
+
+        server = mock_server_factory(routes)
+        streamer = RHEEDStreamer(api_key="k", endpoint=server.endpoint)
+
+        data_id = streamer.initialize(
+            fps=30.0,
+            rotations_per_min=0.0,
+            chunk_size=60,
+            tags=["100", "210", "110"],
+        )
+
+        assert data_id == "data-id-azimuth"
+
+        requests = server.get_captured_requests()
+        tag_reqs = [r for r in requests if r["path"].startswith("/tags/")]
+        # All three exist → no POST /tags/ creates, just GET + attach.
+        methods_paths = [(r["method"], r["path"]) for r in tag_reqs]
+        assert methods_paths == [
+            ("GET", "/tags/"),
+            ("POST", "/tags/data-items/"),
+        ], methods_paths
+
+        attach_body = next(r["body"] for r in tag_reqs if r["path"] == "/tags/data-items/")
+        assert attach_body == {
+            "data_ids": ["data-id-azimuth"],
+            "tag_ids": [id_100, id_210, id_110],
+        }
+
+    def test_initialize_unknown_tag_uuid_raises(self, mock_server_factory):
+        """A UUID that doesn't match any existing tag → RuntimeError."""
+        from atomscale.streaming.rheed_stream import RHEEDStreamer
+
+        existing = [
+            {"id": "11111111-1111-1111-1111-111111111111", "name": "growth"},
+        ]
+        routes = json.dumps({
+            "__routes__": True,
+            "__max_requests__": 3,
+            "/tags/": json.dumps(existing),
+            "/rheed/stream/": '"data-id-unknown-uuid"',
+        })
+
+        server = mock_server_factory(routes)
+        streamer = RHEEDStreamer(api_key="k", endpoint=server.endpoint)
+
+        with pytest.raises(RuntimeError, match="tag with id .* not found"):
+            streamer.initialize(
+                fps=30.0,
+                rotations_per_min=0.0,
+                chunk_size=60,
+                tags=["99999999-9999-9999-9999-999999999999"],
+            )

--- a/tests/test_timeseries_stream.py
+++ b/tests/test_timeseries_stream.py
@@ -191,6 +191,49 @@ class TestTimeseriesStreamerInitialize:
         assert body["stream_name"] == "My Stream"
         assert body["points_per_chunk"] == 50
 
+    def test_initialize_attaches_tag(self, mock_server_factory):
+        """Verify tags wire through TimeseriesStreamer.initialize.
+
+        End-to-end coverage of the shared resolver lives in test_rheed_stream;
+        here we just confirm the wiring: an existing tag is looked up and the
+        bulk-attach POST is fired with the right ids.
+        """
+        from atomscale.streaming.rheed_stream import TimeseriesStreamer
+
+        tag_id = "770e8400-e29b-41d4-a716-446655440002"
+        routes = json.dumps({
+            "__routes__": True,
+            "__max_requests__": 3,
+            "/tags/data-items/": '{"success": true, "associations_created": 1}',
+            "/tags/": json.dumps([{"id": tag_id, "name": "growth"}]),
+            "/metrology/stream/initialize": json.dumps({
+                "data_id": "ts-data-id",
+                "processed_data_id": "ts-proc-id",
+            }),
+        })
+
+        server = mock_server_factory(routes)
+        streamer = TimeseriesStreamer(
+            api_key="k",
+            endpoint=server.endpoint,
+        )
+
+        data_id = streamer.initialize(
+            stream_name="Tagged Stream",
+            tags=["GROWTH"],  # case-insensitive match
+        )
+
+        assert data_id == "ts-data-id"
+
+        requests = server.get_all_requests()
+        # Exactly the three requests we expect, in order.
+        assert any("REQUEST:POST:/metrology/stream/initialize:" in r for r in requests)
+        assert any("REQUEST:GET:/tags/:" in r for r in requests)
+        attach = next(r for r in requests if "/tags/data-items/" in r)
+        # The bulk-attach body must include the resolved tag_id and data_id.
+        assert tag_id in attach
+        assert "ts-data-id" in attach
+
 
 class TestTimeseriesStreamerPush:
     """Tests for TimeseriesStreamer.push() method."""


### PR DESCRIPTION
## Summary
- Adds a `tags` parameter to `RHEEDStreamer.initialize` and `TimeseriesStreamer.initialize`
- Accepts tag names (find-or-create, case-insensitive) or UUIDs (strict lookup); inputs are trimmed and deduped
- Primary use case: attaching RHEED azimuth tags (`"100"`, `"210"`, `"110"`) at stream creation time

## Usage
```python
streamer.initialize(
    fps=30.0,
    rotations_per_min=60.0,
    chunk_size=60,
    tags=["100", "210", "110"],
)
```

## Test plan
- [x] `test_initialize_attaches_azimuth_tags` — pins the azimuth use case
- [x] `test_initialize_resolves_dedupes_and_creates_tags` — find-or-create, dedupe, whitespace, body-shape assertions
- [x] `test_initialize_attaches_tags_with_physical_sample_and_project` — combined flow
- [x] `test_initialize_unknown_tag_uuid_raises` — strict UUID error path
- [x] `test_initialize_attaches_tag` (TimeseriesStreamer) — wiring confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)