### PR TITLE
Packaging: PyInstaller spec for the atomscale-adapters host exe

### DIFF
--- a/.github/workflows/build-adapters-exe.yml
+++ b/.github/workflows/build-adapters-exe.yml
@@ -1,0 +1,50 @@
+name: Build adapters exe
+
+# Builds the standalone `atomscale-adapters` host executable that the
+# file-watcher bundles (Phase 4). This is the validation path for the
+# PyInstaller spec — a missing runtime import fails the `list` smoke test.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [adapter-host-packaging, filmsense-adapters]
+    paths:
+      - "src/atomscale/adapters/**"
+      - "src/atomscale/streaming/**"
+      - "packaging/**"
+      - ".github/workflows/build-adapters-exe.yml"
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Compiling the SDK's Rust extension from source needs a toolchain.
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install SDK + PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pyinstaller
+
+      - name: Build executable
+        run: pyinstaller --clean --noconfirm packaging/atomscale-adapters.spec
+
+      - name: Smoke test (list)
+        run: python packaging/smoke_test_list.py
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: atomscale-adapters-${{ matrix.os }}
+          path: dist/atomscale-adapters*
+          if-no-files-found: error

--- a/.github/workflows/build-adapters-exe.yml
+++ b/.github/workflows/build-adapters-exe.yml
@@ -6,6 +6,11 @@ name: Build adapters exe
 
 on:
   workflow_dispatch:
+  # On a published GitHub Release, build and attach the host binaries as
+  # release assets (same release that release.yml publishes to PyPI), so the
+  # file-watcher can pin the SDK release tag and download the matching exe.
+  release:
+    types: [published]
   push:
     branches: [adapter-host-packaging, filmsense-adapters]
     paths:
@@ -18,6 +23,8 @@ jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # attach the built exe to the GitHub Release (release events)
     strategy:
       fail-fast: false
       matrix:
@@ -48,3 +55,25 @@ jobs:
           name: atomscale-adapters-${{ matrix.os }}
           path: dist/atomscale-adapters*
           if-no-files-found: error
+
+      # --- Release assets (only on a published GitHub Release) ---------------
+      # Give each OS binary a stable, platform-specific asset name so the
+      # file-watcher fetch step can request exactly one.
+      - name: Stage release asset
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          mkdir -p release-asset
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cp dist/atomscale-adapters.exe "release-asset/atomscale-adapters-windows-x64.exe"
+          else
+            cp dist/atomscale-adapters "release-asset/atomscale-adapters-macos-arm64"
+          fi
+
+      - name: Attach binary to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: release-asset/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/build-adapters-exe.yml
+++ b/.github/workflows/build-adapters-exe.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install SDK + PyInstaller
         run: |
           python -m pip install --upgrade pip
-          python -m pip install . pyinstaller
+          python -m pip install . "pyinstaller>=6.0,<7"
 
       - name: Build executable
         run: pyinstaller --clean --noconfirm packaging/atomscale-adapters.spec

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+#  ...but the adapter-host build spec is hand-maintained and must be tracked so
+#  the build scripts and CI can find it (the `*.spec` rule above hides it).
+!packaging/atomscale-adapters.spec
 
 # Installer logs
 pip-log.txt

--- a/packaging/adapters_entry.py
+++ b/packaging/adapters_entry.py
@@ -1,0 +1,12 @@
+"""PyInstaller entry point for the ``atomscale-adapters`` host CLI.
+
+PyInstaller needs a concrete script (not ``-m``) as the frozen entry point.
+This simply delegates to the host CLI's ``main`` (list / run).
+"""
+
+import sys
+
+from atomscale.adapters.__main__ import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/atomscale-adapters.spec
+++ b/packaging/atomscale-adapters.spec
@@ -1,0 +1,93 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the ``atomscale-adapters`` host CLI.
+
+Freezes ``packaging/adapters_entry.py`` (which delegates to
+``atomscale.adapters.__main__:main``) into a single self-contained executable:
+``dist/atomscale-adapters`` (``.exe`` on Windows). The file-watcher app bundles
+this binary and runs ``list`` / ``run <adapter>`` against it.
+
+Built by ``packaging/build-adapters-exe.{sh,ps1}`` and CI
+(``.github/workflows/build-adapters-exe.yml``); validated by
+``packaging/smoke_test_list.py`` (asserts the ``filmsense`` adapter is
+discoverable through ``list``).
+
+Onefile is deliberate: the smoke test and the app both invoke
+``dist/atomscale-adapters`` as a single executable path.
+"""
+
+import os
+
+from PyInstaller.utils.hooks import (
+    collect_dynamic_libs,
+    collect_submodules,
+    copy_metadata,
+)
+
+# Spec scripts are resolved against the CWD pyinstaller runs from (the repo
+# root, per the build scripts). Anchor on SPECPATH so the build works no matter
+# where it is invoked from.
+ENTRY = os.path.join(SPECPATH, "adapters_entry.py")
+
+# Adapters are registered statically in atomscale.adapters.registry, but collect
+# the whole subpackage so adapters added later need no spec edit.
+hiddenimports = collect_submodules("atomscale.adapters")
+
+# The streaming layer is a Rust (PyO3) extension. Depending on how it lands at
+# install time it is importable either as ``atomscale.streaming.rheed_stream``
+# (setuptools-rust target) or via the top-level crate module ``rheed_stream``
+# that ``atomscale/streaming/rheed_stream.py`` re-exports. Cover both names so
+# PyInstaller's static analysis doesn't drop the extension.
+hiddenimports += [
+    "atomscale.streaming",
+    "atomscale.streaming.rheed_stream",
+    "rheed_stream",
+]
+
+# Bundle the compiled extension(s). collect_dynamic_libs walks an importable
+# package; the top-level ``rheed_stream`` may not exist in every layout, so
+# guard it.
+binaries = collect_dynamic_libs("atomscale")
+try:
+    binaries += collect_dynamic_libs("rheed_stream")
+except Exception:
+    pass
+
+# Ship the dist metadata so any importlib.metadata / setuptools-scm version
+# lookup resolves inside the frozen app.
+datas = copy_metadata("atomscale")
+
+a = Analysis(
+    [ENTRY],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="atomscale-adapters",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,  # UPX can corrupt signatures and trip AV; keep the binary intact.
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/packaging/build-adapters-exe.ps1
+++ b/packaging/build-adapters-exe.ps1
@@ -1,0 +1,24 @@
+# Build the `atomscale-adapters` host executable with PyInstaller (Windows).
+#
+# Usage:   powershell -ExecutionPolicy Bypass -File packaging\build-adapters-exe.ps1
+# Output:  dist\atomscale-adapters.exe
+#
+# Requires Python 3.10-3.12 and a Rust toolchain (https://rustup.rs) on PATH,
+# since installing the SDK from source compiles the Rust extension.
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $RepoRoot
+
+$Venv = if ($env:VENV) { $env:VENV } else { ".venv-pyinstaller" }
+python -m venv $Venv
+& "$Venv\Scripts\Activate.ps1"
+
+python -m pip install --upgrade pip
+python -m pip install . pyinstaller
+
+pyinstaller --clean --noconfirm packaging\atomscale-adapters.spec
+
+Write-Host "Built: $RepoRoot\dist\atomscale-adapters.exe"
+& ".\dist\atomscale-adapters.exe" list | Out-Null
+Write-Host "Smoke test 'list' OK"

--- a/packaging/build-adapters-exe.ps1
+++ b/packaging/build-adapters-exe.ps1
@@ -15,10 +15,11 @@ python -m venv $Venv
 & "$Venv\Scripts\Activate.ps1"
 
 python -m pip install --upgrade pip
-python -m pip install . pyinstaller
+python -m pip install . "pyinstaller>=6.0,<7"
 
 pyinstaller --clean --noconfirm packaging\atomscale-adapters.spec
 
 Write-Host "Built: $RepoRoot\dist\atomscale-adapters.exe"
 & ".\dist\atomscale-adapters.exe" list | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "Smoke test 'list' FAILED (exit $LASTEXITCODE)" }
 Write-Host "Smoke test 'list' OK"

--- a/packaging/build-adapters-exe.sh
+++ b/packaging/build-adapters-exe.sh
@@ -19,7 +19,7 @@ source "$VENV/bin/activate"
 
 python -m pip install --upgrade pip
 # Install the SDK (compiles the Rust extension) plus PyInstaller.
-python -m pip install . pyinstaller
+python -m pip install . "pyinstaller>=6.0,<7"
 
 pyinstaller --clean --noconfirm packaging/atomscale-adapters.spec
 

--- a/packaging/build-adapters-exe.sh
+++ b/packaging/build-adapters-exe.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build the `atomscale-adapters` host executable with PyInstaller (macOS / Linux).
+#
+# Usage:   packaging/build-adapters-exe.sh
+# Output:  dist/atomscale-adapters
+#
+# Requires Python 3.10–3.12. Installing the SDK from source builds the Rust
+# extension, so a Rust toolchain (https://rustup.rs) must be on PATH. CI installs
+# Rust via dtolnay/rust-toolchain; see .github/workflows/build-adapters-exe.yml.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VENV="${VENV:-.venv-pyinstaller}"
+python3 -m venv "$VENV"
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+python -m pip install --upgrade pip
+# Install the SDK (compiles the Rust extension) plus PyInstaller.
+python -m pip install . pyinstaller
+
+pyinstaller --clean --noconfirm packaging/atomscale-adapters.spec
+
+echo "Built: $REPO_ROOT/dist/atomscale-adapters"
+./dist/atomscale-adapters list >/dev/null && echo "Smoke test 'list' OK"

--- a/packaging/smoke_test_list.py
+++ b/packaging/smoke_test_list.py
@@ -1,0 +1,25 @@
+"""CI smoke test: the frozen ``atomscale-adapters`` executable lists adapters.
+
+Locates the built binary in ``dist/`` (``.exe`` on Windows), runs ``list``,
+and asserts the FilmSense adapter manifest is present and parseable. A missing
+runtime import (e.g. an over-aggressive PyInstaller exclude) surfaces here.
+"""
+
+import glob
+import json
+import subprocess
+import sys
+
+candidates = sorted(glob.glob("dist/atomscale-adapters*"))
+executables = [c for c in candidates if not c.endswith((".txt", ".log"))]
+if not executables:
+    sys.exit("no built executable found in dist/")
+
+exe = executables[0]
+output = subprocess.check_output([exe, "list"])
+manifests = json.loads(output)
+ids = [adapter["id"] for adapter in manifests]
+print("adapters:", ids)
+
+assert "filmsense" in ids, f"expected 'filmsense' in {ids}"
+print("Smoke test OK")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ dependencies = [
 Homepage = "https://www.atomscale.ai"
 Documentation = "https://atomscale-ai.github.io/sdk"
 
+# Console entry point for the ingestion-adapter host. A plain `pip install`
+# then exposes the `atomscale-adapters` command (list / run <adapter>); the
+# frozen build (packaging/atomscale-adapters.spec) ships the same CLI as a
+# standalone executable for the file-watcher app to bundle.
+[project.scripts]
+atomscale-adapters = "atomscale.adapters.__main__:main"
+
 [tool.setuptools_scm]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

Adds the missing PyInstaller spec so the `atomscale-adapters` host executable actually builds. The build scripts and CI added in `62bf31d` already reference `packaging/atomscale-adapters.spec`, but the file was never tracked — `.gitignore`'s `*.spec` rule silently excluded it, so the build and the **Build adapters exe** workflow could not succeed.

## Changes

- **`packaging/atomscale-adapters.spec`** (new) — onefile spec for `packaging/adapters_entry.py`. Collects `atomscale.adapters` submodules (so registry-based discovery finds adapters added later), bundles the PyO3 streaming extension (handles both the `atomscale.streaming.rheed_stream` and top-level `rheed_stream` layouts), and ships package metadata.
- **`.gitignore`** — adds `!packaging/atomscale-adapters.spec` so the hand-maintained spec stays tracked while auto-generated specs remain ignored. (This is the root cause of the original missing file.)
- **`pyproject.toml`** — `atomscale-adapters` console-script for non-frozen `pip install`s.

## Validation

Built locally on macOS arm64:

- `packaging/build-adapters-exe.sh` → `Smoke test 'list' OK`
- `packaging/smoke_test_list.py` passes
- frozen `./dist/atomscale-adapters list` returns the `filmsense` adapter (v1) with its full config schema

Windows is exercised by the existing `build-adapters-exe.yml` matrix.

## Notes

- Stacked on `filmsense-adapters` (the base of this PR), which still needs its own merge to `main`.
- The onefile binary is ~60 MB — it bundles numpy/scipy/pandas/matplotlib, which the SDK pulls in transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
