### PR TITLE
RHEED low-level features + embedding-vector query

### DIFF
--- a/src/atomscale/client.py
+++ b/src/atomscale/client.py
@@ -27,6 +27,7 @@ from atomscale.results import (
     OpticalResult,
     PhotoluminescenceResult,
     RamanResult,
+    RHEEDEmbeddingResult,
     RHEEDImageResult,
     RHEEDVideoResult,
     SimilarityTrajectoryResult,
@@ -280,7 +281,7 @@ class Client(BaseClient):
         return catalogue[ordered_cols]
 
     def get(
-        self, data_ids: str | list[str]
+        self, data_ids: str | list[str], *, include_low_level_features: bool = False
     ) -> list[
         RHEEDVideoResult
         | RHEEDImageResult
@@ -297,6 +298,10 @@ class Client(BaseClient):
 
         Args:
             data_ids (str | list[str]): Data ID or list of data IDs from the data catalogue to obtain analyzed results for.
+            include_low_level_features (bool): For RHEED video results only, attach the
+                pipeline's low-level region features (e.g. ``area_0``, ``eccentricity_0``,
+                ``fwhm_0_3``) as extra columns on ``timeseries_data``. Off by default; the
+                payload is larger when enabled. Ignored for non-RHEED data types.
 
         Returns:
             list[atomscale.results.RHEEDVideoResult | atomscale.results.RHEEDImageResult | atomscale.results.XPSResult | atomscale.results.XRDResult]:
@@ -336,6 +341,7 @@ class Client(BaseClient):
                     "data_id": data_id,
                     "data_type": data_type,
                     "catalogue_entry": entry,
+                    "include_low_level_features": include_low_level_features,
                 }
             )
 
@@ -473,6 +479,95 @@ class Client(BaseClient):
             workflow=workflow,
             window_span=window_span or 0.0,
         )
+
+    def get_rheed_embeddings(
+        self,
+        data_id: str,
+        *,
+        workflow: str = "rheed_stationary",
+        window_span: float = 30.0,
+        kind: Literal["window", "prototype"] = "window",
+        offset: int = 0,
+        limit: int | None = None,
+    ) -> RHEEDEmbeddingResult:
+        """Fetch the stored Chronos embedding vectors for a RHEED data item.
+
+        These are the raw timeseries embeddings the similarity pipeline persisted
+        to the S3 Vectors index — the *inputs* to similarity matching, as opposed
+        to the similarity-vs-time curve returned by
+        :meth:`get_similarity_trajectory`.
+
+        Args:
+            data_id: Data ID to fetch embeddings for.
+            workflow: Similarity workflow name. Defaults to "rheed_stationary".
+            window_span: Embedding window span in seconds. Must match a span the
+                embedding step actually ran for, or the result is empty.
+            kind: "window" for one vector per sliding window (time-resolved), or
+                "prototype" for the clustered prototype vectors.
+            offset: Window kind only — skip this many leading windows.
+            limit: Window kind only — cap the number of windows returned.
+
+        Returns:
+            RHEEDEmbeddingResult with an ``(N, D)`` ``vectors`` array. Empty (no
+            vectors) when nothing has been embedded for this (data_id, window_span).
+        """
+        # Local import mirrors the similarity-polling methods below: importing
+        # the similarity package at module top triggers a timeseries<->similarity
+        # registry import cycle.
+        from atomscale.similarity.embedding_provider import RHEEDEmbeddingProvider
+
+        provider = RHEEDEmbeddingProvider()
+        params: dict[str, Any] = {
+            "workflow": workflow,
+            "window_span": window_span,
+            "kind": kind,
+        }
+        if offset:
+            params["offset"] = offset
+        if limit is not None:
+            params["limit"] = limit
+
+        raw = provider.fetch_raw(self, data_id, **params)
+        return provider.to_result(raw)
+
+    def query_rheed_embeddings(
+        self,
+        data_id: str,
+        *,
+        workflow: str = "rheed_stationary",
+        window_span: float = 30.0,
+        kind: Literal["prototype", "window"] = "prototype",
+        top_k: int = 10,
+    ) -> DataFrame:
+        """Find RHEED data items whose embeddings are most similar to this one.
+
+        Runs k-NN over the embedding index using this item's own vectors and
+        returns the best-matching *other* data items ("find similar growths").
+
+        Args:
+            data_id: Data ID whose vectors seed the query.
+            workflow: Similarity workflow name. Defaults to "rheed_stationary".
+            window_span: Embedding window span in seconds (must match an embedded span).
+            kind: "prototype" (coarse, default) or "window" (finer, more queries).
+            top_k: Max neighbors to return. The backend caps this at 30.
+
+        Returns:
+            DataFrame with columns ``data_id``, ``similarity`` (1 = identical), and
+            locus columns (``source_index``, ``neighbor_index``, ``real_time_seconds``,
+            ``unix_time_ms``), sorted by descending similarity. Empty when this item
+            has no embeddings for the given (workflow, window_span).
+        """
+        from atomscale.similarity.embedding_provider import RHEEDEmbeddingProvider
+
+        provider = RHEEDEmbeddingProvider()
+        params: dict[str, Any] = {
+            "workflow": workflow,
+            "window_span": window_span,
+            "kind": kind,
+            "top_k": top_k,
+        }
+        raw = provider.fetch_neighbors_raw(self, data_id, **params)
+        return provider.neighbors_to_dataframe(raw)
 
     def iter_poll_similarity_trajectory(
         self,
@@ -841,6 +936,7 @@ class Client(BaseClient):
             "ellipsometry",
         ],
         catalogue_entry: dict[str, Any] | None = None,
+        include_low_level_features: bool = False,
     ) -> (
         RHEEDVideoResult
         | RHEEDImageResult
@@ -943,8 +1039,12 @@ class Client(BaseClient):
             )
             provider = get_provider(timeseries_type)
 
-            # Get timeseries data
-            raw = provider.fetch_raw(self, data_id)
+            # Get timeseries data. Only the RHEED provider/endpoint understands
+            # include_low_level_features; other timeseries types ignore the flag.
+            fetch_kwargs: dict[str, Any] = {}
+            if include_low_level_features and "rheed" in data_type:
+                fetch_kwargs["include_low_level_features"] = True
+            raw = provider.fetch_raw(self, data_id, **fetch_kwargs)
             ts_df = provider.to_dataframe(raw)
 
             result_obj = provider.build_result(self, data_id, data_type, ts_df)

--- a/src/atomscale/results/__init__.py
+++ b/src/atomscale/results/__init__.py
@@ -5,6 +5,7 @@ from .metrology import MetrologyResult
 from .optical import OpticalResult
 from .photoluminescence import PhotoluminescenceResult
 from .raman import RamanResult
+from .rheed_embedding import RHEEDEmbeddingResult
 from .rheed_image import RHEEDImageCollection, RHEEDImageResult, _get_rheed_image_result
 from .rheed_video import RHEEDVideoResult
 from .similarity_trajectory import SimilarityTrajectoryResult
@@ -20,6 +21,7 @@ __all__ = [
     "PhotoluminescenceResult",
     "PhysicalSampleResult",
     "ProjectResult",
+    "RHEEDEmbeddingResult",
     "RHEEDImageCollection",
     "RHEEDImageResult",
     "RHEEDVideoResult",

--- a/src/atomscale/results/rheed_embedding.py
+++ b/src/atomscale/results/rheed_embedding.py
@@ -55,7 +55,9 @@ class RHEEDEmbeddingResult(MSONable):
         self.kind = kind
         arr = np.asarray(vectors, dtype=np.float32)
         # Normalize an empty/degenerate array to a clean (0, 0) shape.
-        self.vectors: NDArray = arr if arr.ndim == 2 and arr.size else np.zeros((0, 0), np.float32)
+        self.vectors: NDArray = (
+            arr if arr.ndim == 2 and arr.size else np.zeros((0, 0), np.float32)
+        )
         self.indices: list[int] = list(indices)
         self.real_time_seconds = (
             np.asarray(real_time_seconds, dtype=np.float64)
@@ -63,12 +65,16 @@ class RHEEDEmbeddingResult(MSONable):
             else None
         )
         self.unix_time_ms = (
-            np.asarray(unix_time_ms, dtype=np.float64) if unix_time_ms is not None else None
+            np.asarray(unix_time_ms, dtype=np.float64)
+            if unix_time_ms is not None
+            else None
         )
         # float64 (not int64) so a partial/missing cluster_size (None) coerces to
         # NaN rather than raising at array construction.
         self.cluster_sizes = (
-            np.asarray(cluster_sizes, dtype=np.float64) if cluster_sizes is not None else None
+            np.asarray(cluster_sizes, dtype=np.float64)
+            if cluster_sizes is not None
+            else None
         )
         self.count = count if count is not None else int(self.vectors.shape[0])
         self.truncated = truncated
@@ -94,13 +100,13 @@ class RHEEDEmbeddingResult(MSONable):
             cols["unix_time_ms"] = list(self.unix_time_ms)
         if self.cluster_sizes is not None:
             cols["cluster_size"] = list(self.cluster_sizes)
-        df = DataFrame(cols)
+        frame = DataFrame(cols)
 
         dim = self.dimension
         if len(self) and dim:
             vec_df = DataFrame(self.vectors, columns=[f"v{i}" for i in range(dim)])
-            df = concat([df, vec_df], axis=1)
+            frame = concat([frame, vec_df], axis=1)
 
-        if "index" in df.columns:
-            df = df.set_index("index")
-        return df
+        if "index" in frame.columns:
+            frame = frame.set_index("index")
+        return frame

--- a/src/atomscale/results/rheed_embedding.py
+++ b/src/atomscale/results/rheed_embedding.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+import numpy as np
+from monty.json import MSONable
+from numpy.typing import NDArray
+from pandas import DataFrame, concat
+
+
+class RHEEDEmbeddingResult(MSONable):
+    """Raw Chronos timeseries embedding vectors for a single RHEED data item.
+
+    These are the per-window or clustered-prototype vectors the similarity
+    embed-store persisted to the S3 Vectors index — the *inputs* to the
+    similarity comparison, distinct from
+    :class:`~atomscale.results.SimilarityTrajectoryResult`, which carries the
+    derived similarity-vs-time curve (the *output*).
+
+    Args:
+        data_id: The data ID the embeddings belong to.
+        workflow: Similarity workflow name (e.g. ``"rheed_stationary"``).
+        window_span: Embedding window span in seconds the vectors were built at.
+        kind: ``"window"`` (one vector per sliding window, time-resolved) or
+            ``"prototype"`` (clustered prototype vectors).
+        vectors: ``(N, D)`` float32 array of embedding vectors.
+        indices: Length-``N`` window indices (``kind="window"``) or prototype
+            indices (``kind="prototype"``).
+        real_time_seconds: Length-``N`` window times in seconds (window kind only).
+        unix_time_ms: Length-``N`` absolute window times in ms (window kind only).
+        cluster_sizes: Length-``N`` prototype cluster sizes (prototype kind only).
+        count: Total vectors available server-side before any offset/limit slice.
+        truncated: True when the server hit its per-item window cap (the series
+            may be incomplete).
+    """
+
+    def __init__(
+        self,
+        data_id: UUID | str,
+        workflow: str,
+        window_span: float,
+        kind: str,
+        vectors: NDArray | Sequence[Sequence[float]],
+        indices: Sequence[int],
+        real_time_seconds: NDArray | None = None,
+        unix_time_ms: NDArray | None = None,
+        cluster_sizes: NDArray | None = None,
+        count: int | None = None,
+        truncated: bool = False,
+    ):
+        self.data_id = data_id
+        self.workflow = workflow
+        self.window_span = window_span
+        self.kind = kind
+        arr = np.asarray(vectors, dtype=np.float32)
+        # Normalize an empty/degenerate array to a clean (0, 0) shape.
+        self.vectors: NDArray = arr if arr.ndim == 2 and arr.size else np.zeros((0, 0), np.float32)
+        self.indices: list[int] = list(indices)
+        self.real_time_seconds = (
+            np.asarray(real_time_seconds, dtype=np.float64)
+            if real_time_seconds is not None
+            else None
+        )
+        self.unix_time_ms = (
+            np.asarray(unix_time_ms, dtype=np.float64) if unix_time_ms is not None else None
+        )
+        self.cluster_sizes = (
+            np.asarray(cluster_sizes, dtype=np.int64) if cluster_sizes is not None else None
+        )
+        self.count = count if count is not None else int(self.vectors.shape[0])
+        self.truncated = truncated
+
+    @property
+    def dimension(self) -> int | None:
+        """Embedding dimensionality D, or None when there are no vectors."""
+        if self.vectors.ndim == 2 and self.vectors.shape[0] > 0:
+            return int(self.vectors.shape[1])
+        return None
+
+    def __len__(self) -> int:
+        return int(self.vectors.shape[0])
+
+    def to_dataframe(self) -> DataFrame:
+        """Return one row per vector: locus/metadata columns + ``v0..v{D-1}``,
+        indexed by the window/prototype index.
+        """
+        cols: dict[str, object] = {"index": self.indices}
+        if self.real_time_seconds is not None:
+            cols["real_time_seconds"] = list(self.real_time_seconds)
+        if self.unix_time_ms is not None:
+            cols["unix_time_ms"] = list(self.unix_time_ms)
+        if self.cluster_sizes is not None:
+            cols["cluster_size"] = list(self.cluster_sizes)
+        df = DataFrame(cols)
+
+        dim = self.dimension
+        if len(self) and dim:
+            vec_df = DataFrame(self.vectors, columns=[f"v{i}" for i in range(dim)])
+            df = concat([df, vec_df], axis=1)
+
+        if "index" in df.columns:
+            df = df.set_index("index")
+        return df

--- a/src/atomscale/results/rheed_embedding.py
+++ b/src/atomscale/results/rheed_embedding.py
@@ -65,8 +65,10 @@ class RHEEDEmbeddingResult(MSONable):
         self.unix_time_ms = (
             np.asarray(unix_time_ms, dtype=np.float64) if unix_time_ms is not None else None
         )
+        # float64 (not int64) so a partial/missing cluster_size (None) coerces to
+        # NaN rather than raising at array construction.
         self.cluster_sizes = (
-            np.asarray(cluster_sizes, dtype=np.int64) if cluster_sizes is not None else None
+            np.asarray(cluster_sizes, dtype=np.float64) if cluster_sizes is not None else None
         )
         self.count = count if count is not None else int(self.vectors.shape[0])
         self.truncated = truncated

--- a/src/atomscale/similarity/embedding_provider.py
+++ b/src/atomscale/similarity/embedding_provider.py
@@ -71,7 +71,7 @@ class RHEEDEmbeddingProvider:
             vectors = np.asarray([p.get("vector", []) for p in points], dtype=np.float32)
         else:
             vectors = np.zeros((0, 0), dtype=np.float32)
-        indices = [p.get("index") for p in points]
+        indices = [p["index"] for p in points]
 
         real_time = None
         unix_time = None

--- a/src/atomscale/similarity/embedding_provider.py
+++ b/src/atomscale/similarity/embedding_provider.py
@@ -46,7 +46,9 @@ class RHEEDEmbeddingProvider:
             params=kwargs,
         )
 
-    def fetch_neighbors_raw(self, client: BaseClient, data_id: str, **kwargs: Any) -> Any:
+    def fetch_neighbors_raw(
+        self, client: BaseClient, data_id: str, **kwargs: Any
+    ) -> Any:
         """Fetch k-NN neighbors ("find similar") for a data_id.
 
         Args:
@@ -68,7 +70,9 @@ class RHEEDEmbeddingProvider:
         kind = raw.get("kind", "window")
 
         if points:
-            vectors = np.asarray([p.get("vector", []) for p in points], dtype=np.float32)
+            vectors = np.asarray(
+                [p.get("vector", []) for p in points], dtype=np.float32
+            )
         else:
             vectors = np.zeros((0, 0), dtype=np.float32)
         indices = [p["index"] for p in points]
@@ -104,7 +108,7 @@ class RHEEDEmbeddingProvider:
         neighbors = (raw or {}).get("neighbors", []) or []
         if not neighbors:
             return DataFrame(columns=_NEIGHBOR_COLUMNS)
-        df = DataFrame(neighbors)
-        ordered = [c for c in _NEIGHBOR_COLUMNS if c in df.columns]
-        extra = [c for c in df.columns if c not in _NEIGHBOR_COLUMNS]
-        return df[ordered + extra]
+        frame = DataFrame(neighbors)
+        ordered = [c for c in _NEIGHBOR_COLUMNS if c in frame.columns]
+        extra = [c for c in frame.columns if c not in _NEIGHBOR_COLUMNS]
+        return frame[ordered + extra]

--- a/src/atomscale/similarity/embedding_provider.py
+++ b/src/atomscale/similarity/embedding_provider.py
@@ -1,0 +1,110 @@
+"""Provider for RHEED timeseries embedding vectors and k-NN neighbor queries.
+
+Wraps the read-only embedding endpoints the backend exposes under
+``/similarity/{workflow}/{data_id}/embeddings/`` (raw vectors) and
+``.../embeddings/neighbors/`` (k-NN "find similar"). Mirrors the fetch/build
+split of :class:`~atomscale.similarity.provider.SimilarityTrajectoryProvider`,
+but returns a numpy-backed :class:`RHEEDEmbeddingResult` rather than a
+timeseries DataFrame, so it is intentionally not a ``TimeseriesProvider``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from pandas import DataFrame
+
+from atomscale.core import BaseClient
+from atomscale.results.rheed_embedding import RHEEDEmbeddingResult
+
+_NEIGHBOR_COLUMNS = [
+    "data_id",
+    "similarity",
+    "source_index",
+    "neighbor_index",
+    "real_time_seconds",
+    "unix_time_ms",
+]
+
+
+class RHEEDEmbeddingProvider:
+    TYPE = "rheed_embeddings"
+
+    def fetch_raw(self, client: BaseClient, data_id: str, **kwargs: Any) -> Any:
+        """Fetch stored embedding vectors for a data_id.
+
+        Args:
+            client: The API client.
+            data_id: The data ID to fetch embeddings for.
+            **kwargs: Must include ``workflow``. Optional: ``window_span``,
+                ``kind`` ("window"|"prototype"), ``offset``, ``limit``.
+        """
+        workflow = kwargs.pop("workflow")
+        return client._get(
+            sub_url=f"similarity/{workflow}/{data_id}/embeddings/",
+            params=kwargs,
+        )
+
+    def fetch_neighbors_raw(self, client: BaseClient, data_id: str, **kwargs: Any) -> Any:
+        """Fetch k-NN neighbors ("find similar") for a data_id.
+
+        Args:
+            client: The API client.
+            data_id: The data ID whose vectors seed the query.
+            **kwargs: Must include ``workflow``. Optional: ``window_span``,
+                ``kind`` ("prototype"|"window"), ``top_k``.
+        """
+        workflow = kwargs.pop("workflow")
+        return client._get(
+            sub_url=f"similarity/{workflow}/{data_id}/embeddings/neighbors/",
+            params=kwargs,
+        )
+
+    def to_result(self, raw: Any) -> RHEEDEmbeddingResult:
+        """Build a RHEEDEmbeddingResult from a fetch_raw payload."""
+        raw = raw or {}
+        points = raw.get("points", []) or []
+        kind = raw.get("kind", "window")
+
+        if points:
+            vectors = np.asarray([p.get("vector", []) for p in points], dtype=np.float32)
+        else:
+            vectors = np.zeros((0, 0), dtype=np.float32)
+        indices = [p.get("index") for p in points]
+
+        real_time = None
+        unix_time = None
+        cluster_sizes = None
+        if kind == "window":
+            if any(p.get("real_time_seconds") is not None for p in points):
+                real_time = [p.get("real_time_seconds") for p in points]
+            if any(p.get("unix_time_ms") is not None for p in points):
+                unix_time = [p.get("unix_time_ms") for p in points]
+        elif any(p.get("cluster_size") is not None for p in points):
+            cluster_sizes = [p.get("cluster_size") for p in points]
+
+        return RHEEDEmbeddingResult(
+            data_id=raw.get("data_id"),
+            workflow=raw.get("workflow", ""),
+            window_span=raw.get("window_span", 0.0),
+            kind=kind,
+            vectors=vectors,
+            indices=indices,
+            real_time_seconds=real_time,
+            unix_time_ms=unix_time,
+            cluster_sizes=cluster_sizes,
+            count=raw.get("count"),
+            truncated=bool(raw.get("truncated", False)),
+        )
+
+    @staticmethod
+    def neighbors_to_dataframe(raw: Any) -> DataFrame:
+        """Build a tidy neighbors DataFrame from a fetch_neighbors_raw payload."""
+        neighbors = (raw or {}).get("neighbors", []) or []
+        if not neighbors:
+            return DataFrame(columns=_NEIGHBOR_COLUMNS)
+        df = DataFrame(neighbors)
+        ordered = [c for c in _NEIGHBOR_COLUMNS if c in df.columns]
+        extra = [c for c in df.columns if c not in _NEIGHBOR_COLUMNS]
+        return df[ordered + extra]

--- a/src/atomscale/timeseries/rheed.py
+++ b/src/atomscale/timeseries/rheed.py
@@ -107,7 +107,9 @@ class RHEEDProvider(TimeseriesProvider[RHEEDVideoResult]):
         if "low_level_features" not in angle_df.columns:
             return angle_df
         nested = angle_df["low_level_features"]
-        expanded = json_normalize([v if isinstance(v, dict) else {} for v in nested], max_level=1)
+        expanded = json_normalize(
+            [v if isinstance(v, dict) else {} for v in nested], max_level=1
+        )
         expanded.index = angle_df.index
         angle_df = angle_df.drop(columns=["low_level_features"])
         # Defensive: never clobber an existing top-level column.

--- a/src/atomscale/timeseries/rheed.py
+++ b/src/atomscale/timeseries/rheed.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from pandas import DataFrame, concat
+from pandas import DataFrame, concat, json_normalize
 
 from atomscale.core import BaseClient
 from atomscale.results import (
@@ -63,10 +63,14 @@ class RHEEDProvider(TimeseriesProvider[RHEEDVideoResult]):
             series = angle_block.get("series") or []
             if not series:
                 continue
+            # Flatten the nested low_level_features dict (present only when the
+            # request set include_low_level_features) into one column per feature
+            # BEFORE the all-NA drop, so empty low-level columns get pruned too.
+            angle_df = self._expand_low_level_features(DataFrame(series))
             # Drop columns that are all-NA within this angle block before concat;
             # otherwise pandas issues a FutureWarning about empty/all-NA entries
             # widening the result dtype.
-            angle_df = DataFrame(series).dropna(axis=1, how="all")
+            angle_df = angle_df.dropna(axis=1, how="all")
             angle_df["Angle"] = angle_block["angle"]
             frames.append(angle_df)
 
@@ -88,6 +92,29 @@ class RHEEDProvider(TimeseriesProvider[RHEEDVideoResult]):
             df_all = df_all.set_index(idx_cols)
 
         return df_all
+
+    @staticmethod
+    def _expand_low_level_features(angle_df: DataFrame) -> DataFrame:
+        """Flatten the nested ``low_level_features`` column into one column per
+        feature.
+
+        The backend attaches a ``low_level_features`` dict (e.g.
+        ``{"area_0": ..., "eccentricity_0": ...}``) to each point only when the
+        request set ``include_low_level_features``. Expand it so each feature
+        becomes its own column; missing keys/points become NaN. These columns
+        are not in ``RENAME_MAP``, so they keep their raw backend names.
+        """
+        if "low_level_features" not in angle_df.columns:
+            return angle_df
+        nested = angle_df["low_level_features"]
+        expanded = json_normalize([v if isinstance(v, dict) else {} for v in nested])
+        expanded.index = angle_df.index
+        angle_df = angle_df.drop(columns=["low_level_features"])
+        # Defensive: never clobber an existing top-level column.
+        new_cols = [c for c in expanded.columns if c not in angle_df.columns]
+        if new_cols:
+            angle_df = concat([angle_df, expanded[new_cols]], axis=1)
+        return angle_df
 
     def snapshot_url(self, data_id: str) -> str:
         return f"data_entries/video_single_frames/{data_id}"

--- a/src/atomscale/timeseries/rheed.py
+++ b/src/atomscale/timeseries/rheed.py
@@ -107,7 +107,7 @@ class RHEEDProvider(TimeseriesProvider[RHEEDVideoResult]):
         if "low_level_features" not in angle_df.columns:
             return angle_df
         nested = angle_df["low_level_features"]
-        expanded = json_normalize([v if isinstance(v, dict) else {} for v in nested])
+        expanded = json_normalize([v if isinstance(v, dict) else {} for v in nested], max_level=1)
         expanded.index = angle_df.index
         angle_df = angle_df.drop(columns=["low_level_features"])
         # Defensive: never clobber an existing top-level column.

--- a/tests/test_rheed_embedding.py
+++ b/tests/test_rheed_embedding.py
@@ -79,6 +79,27 @@ def test_to_result_prototype():
     assert "cluster_size" in r.to_dataframe().columns
 
 
+def test_to_result_prototype_partial_cluster_size():
+    """cluster_size present on some points but missing on others must coerce the
+    gaps to NaN (float64) instead of crashing at array construction."""
+    raw = {
+        "kind": "prototype",
+        "data_id": "abc",
+        "workflow": "w",
+        "window_span": 30.0,
+        "count": 3,
+        "points": [
+            {"index": 0, "vector": [1.0, 2.0], "cluster_size": 7},
+            {"index": 1, "vector": [3.0, 4.0]},  # missing cluster_size
+            {"index": 2, "vector": [5.0, 6.0], "cluster_size": 5},
+        ],
+    }
+    r = RHEEDEmbeddingProvider().to_result(raw)
+    assert r.cluster_sizes[0] == 7
+    assert np.isnan(r.cluster_sizes[1])
+    assert r.cluster_sizes[2] == 5
+
+
 def test_to_result_empty():
     r = RHEEDEmbeddingProvider().to_result({"kind": "window", "points": []})
     assert len(r) == 0

--- a/tests/test_rheed_embedding.py
+++ b/tests/test_rheed_embedding.py
@@ -1,0 +1,166 @@
+import os
+
+import numpy as np
+import pytest
+from pandas import DataFrame
+
+from atomscale import Client
+from atomscale.results import RHEEDEmbeddingResult
+from atomscale.similarity.embedding_provider import RHEEDEmbeddingProvider
+
+from .conftest import ResultIDs
+
+# --------------------------- pure unit tests (no network) ---------------------------
+
+
+def test_type_constant():
+    assert RHEEDEmbeddingProvider.TYPE == "rheed_embeddings"
+
+
+def test_to_result_window():
+    raw = {
+        "data_id": "abc",
+        "workflow": "rheed_stationary",
+        "window_span": 30.0,
+        "kind": "window",
+        "dimension": 3,
+        "count": 2,
+        "offset": 0,
+        "truncated": False,
+        "points": [
+            {"index": 0, "vector": [0.1, 0.2, 0.3], "real_time_seconds": 1.0, "unix_time_ms": 1000.0},
+            {"index": 1, "vector": [0.4, 0.5, 0.6], "real_time_seconds": 2.0, "unix_time_ms": 2000.0},
+        ],
+    }
+    r = RHEEDEmbeddingProvider().to_result(raw)
+    assert isinstance(r, RHEEDEmbeddingResult)
+    assert r.kind == "window"
+    assert r.vectors.shape == (2, 3)
+    assert r.dimension == 3
+    assert len(r) == 2
+    assert r.indices == [0, 1]
+    assert list(r.real_time_seconds) == [1.0, 2.0]
+    assert list(r.unix_time_ms) == [1000.0, 2000.0]
+    assert r.cluster_sizes is None
+
+
+def test_to_result_window_dataframe():
+    raw = {
+        "kind": "window",
+        "data_id": "abc",
+        "workflow": "w",
+        "window_span": 30.0,
+        "count": 2,
+        "points": [
+            {"index": 0, "vector": [0.1, 0.2], "real_time_seconds": 1.0, "unix_time_ms": 1000.0},
+            {"index": 1, "vector": [0.3, 0.4], "real_time_seconds": 2.0, "unix_time_ms": 2000.0},
+        ],
+    }
+    df = RHEEDEmbeddingProvider().to_result(raw).to_dataframe()
+    assert df.index.name == "index"
+    assert "real_time_seconds" in df.columns
+    assert "unix_time_ms" in df.columns
+    assert {"v0", "v1"} <= set(df.columns)
+
+
+def test_to_result_prototype():
+    raw = {
+        "kind": "prototype",
+        "data_id": "abc",
+        "workflow": "w",
+        "window_span": 30.0,
+        "count": 1,
+        "points": [{"index": 0, "vector": [1.0, 2.0], "cluster_size": 7}],
+    }
+    r = RHEEDEmbeddingProvider().to_result(raw)
+    assert r.kind == "prototype"
+    assert list(r.cluster_sizes) == [7]
+    assert r.real_time_seconds is None
+    assert "cluster_size" in r.to_dataframe().columns
+
+
+def test_to_result_empty():
+    r = RHEEDEmbeddingProvider().to_result({"kind": "window", "points": []})
+    assert len(r) == 0
+    assert r.dimension is None
+    assert r.to_dataframe().shape[0] == 0
+
+
+def test_to_result_none_payload():
+    r = RHEEDEmbeddingProvider().to_result(None)
+    assert len(r) == 0
+    assert r.dimension is None
+
+
+def test_neighbors_to_dataframe():
+    raw = {
+        "neighbors": [
+            {"data_id": "x", "similarity": 0.9, "source_index": 0, "neighbor_index": 3,
+             "real_time_seconds": None, "unix_time_ms": None},
+            {"data_id": "y", "similarity": 0.7, "source_index": 1, "neighbor_index": 0,
+             "real_time_seconds": None, "unix_time_ms": None},
+        ]
+    }
+    df = RHEEDEmbeddingProvider().neighbors_to_dataframe(raw)
+    assert list(df.columns)[:2] == ["data_id", "similarity"]
+    assert df.iloc[0]["data_id"] == "x"
+    assert df.iloc[0]["similarity"] == 0.9
+
+
+def test_neighbors_to_dataframe_empty():
+    df = RHEEDEmbeddingProvider().neighbors_to_dataframe({"neighbors": []})
+    assert isinstance(df, DataFrame)
+    assert list(df.columns) == [
+        "data_id", "similarity", "source_index", "neighbor_index",
+        "real_time_seconds", "unix_time_ms",
+    ]
+    assert df.empty
+
+
+def test_result_dimension_and_len_when_empty():
+    r = RHEEDEmbeddingResult(
+        data_id="a", workflow="w", window_span=30.0, kind="window",
+        vectors=np.zeros((0, 0), np.float32), indices=[],
+    )
+    assert r.dimension is None
+    assert len(r) == 0
+
+
+# --------------------------- live-API tests (gated on creds) ---------------------------
+
+
+def _skip_without_api():
+    if not os.getenv("AS_API_KEY") and not os.getenv("ATOMSCALE_API_KEY"):
+        pytest.skip("No API key configured for live embedding tests")
+    if not ResultIDs.similarity_source_id or not ResultIDs.similarity_workflow:
+        pytest.skip("No similarity source configured")
+
+
+def test_get_rheed_embeddings_live():
+    _skip_without_api()
+    result = Client().get_rheed_embeddings(
+        ResultIDs.similarity_source_id,
+        workflow=ResultIDs.similarity_workflow,
+        window_span=30.0,
+        kind="prototype",
+    )
+    assert isinstance(result, RHEEDEmbeddingResult)
+    if len(result) == 0:
+        pytest.skip("No embeddings stored for this source/window_span")
+    assert result.vectors.shape[0] == len(result.indices)
+    assert result.dimension == result.vectors.shape[1]
+
+
+def test_query_rheed_embeddings_live():
+    _skip_without_api()
+    df = Client().query_rheed_embeddings(
+        ResultIDs.similarity_source_id,
+        workflow=ResultIDs.similarity_workflow,
+        window_span=30.0,
+        kind="prototype",
+        top_k=5,
+    )
+    assert isinstance(df, DataFrame)
+    # the source item must never be returned as its own neighbor
+    if not df.empty:
+        assert str(ResultIDs.similarity_source_id) not in set(df["data_id"].astype(str))

--- a/tests/test_rheed_video.py
+++ b/tests/test_rheed_video.py
@@ -3,6 +3,7 @@ from pandas import DataFrame
 
 from atomscale import Client
 from atomscale.results import RHEEDVideoResult
+from atomscale.timeseries.rheed import RHEEDProvider
 
 from .conftest import ResultIDs
 
@@ -53,3 +54,60 @@ def test_get_dataframe(result: RHEEDVideoResult):
     assert isinstance(result.timeseries_data, DataFrame)
     assert not len(set(result.timeseries_data.keys().values) - column_names)
     assert result.timeseries_data.index.names == ["Angle", "Frame Number"]
+
+
+def test_to_dataframe_flattens_low_level_features():
+    """When include_low_level_features is set, the backend nests a
+    low_level_features dict per point; the provider flattens it into raw-named
+    columns (no RENAME_MAP entry) and drops the nested column."""
+    raw = {
+        "series_by_angle": [
+            {
+                "angle": "0",
+                "series": [
+                    {
+                        "frame_number": 0,
+                        "relative_time_seconds": 0.0,
+                        "unix_timestamp_ms": 0.0,
+                        "specular_intensity": 5.0,
+                        "low_level_features": {"area_0": 1.2, "eccentricity_0": 0.3},
+                    },
+                    {
+                        "frame_number": 1,
+                        "relative_time_seconds": 0.1,
+                        "unix_timestamp_ms": 100.0,
+                        "specular_intensity": 6.0,
+                        "low_level_features": {"area_0": 1.5, "eccentricity_0": 0.4},
+                    },
+                ],
+            }
+        ]
+    }
+    df = RHEEDProvider().to_dataframe(raw)
+    assert "area_0" in df.columns
+    assert "eccentricity_0" in df.columns
+    assert "low_level_features" not in df.columns
+    assert "Specular Intensity" in df.columns  # RENAME_MAP still applied
+    assert df["area_0"].tolist() == [1.2, 1.5]
+
+
+def test_to_dataframe_without_low_level_features():
+    """No low_level_features key (flag off) -> no extra columns."""
+    raw = {
+        "series_by_angle": [
+            {
+                "angle": "0",
+                "series": [
+                    {
+                        "frame_number": 0,
+                        "relative_time_seconds": 0.0,
+                        "unix_timestamp_ms": 0.0,
+                        "specular_intensity": 5.0,
+                    }
+                ],
+            }
+        ]
+    }
+    df = RHEEDProvider().to_dataframe(raw)
+    assert "area_0" not in df.columns
+    assert "low_level_features" not in df.columns


### PR DESCRIPTION
Exposes two RHEED capabilities through the SDK, backed by atom-cloud PR [#1840](https://github.com/atomscale-ai/atom-cloud/pull/1840) (which adds the corresponding backend routes + response field).

## Low-level RHEED features
`client.get(data_ids, include_low_level_features=True)` now surfaces the pipeline's region-level features (`area_n`, `eccentricity_n`, `fwhm_0_n`, profile skews/CVs, …) as extra columns on `RHEEDVideoResult.timeseries_data`. The backend nests them per-point under `low_level_features`; `RHEEDProvider.to_dataframe` flattens that into raw-named columns. Off by default; ignored for non-RHEED types.

## Embedding-vector query
The raw Chronos timeseries embeddings (the *inputs* to similarity matching, vs. the derived curve from `get_similarity_trajectory`) are now reachable:
- `client.get_rheed_embeddings(data_id, *, workflow, window_span, kind="window"|"prototype", offset, limit)` → `RHEEDEmbeddingResult` — numpy `(N, D)` `vectors` + time axis / cluster sizes, with `.to_dataframe()`.
- `client.query_rheed_embeddings(data_id, *, workflow, window_span, kind, top_k)` → tidy neighbors `DataFrame` ("find similar growths"), source excluded, sorted by similarity.

New `RHEEDEmbeddingProvider` (under `atomscale/similarity/`) mirrors the existing `SimilarityTrajectoryProvider` fetch/build split; `RHEEDEmbeddingResult` is exported from `atomscale.results`.

## Tests
New pure unit tests (no network) for the provider/result conversions and the low-level flatten, plus creds-gated live integration tests. `26 passed, 2 skipped` locally; full suite still collects (141) and `test_core`/`test_align` stay green.

> Note: requires atom-cloud #1840 (the `include_low_level_features` flag + `/embeddings/` routes) deployed for the live paths to return data; `window_span` must match an embedded span or results are empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)