### PR TITLE
Add embedding, similarity match, and RHEED timeseries SDK support

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -10,6 +10,7 @@ Reference documentation for modules pulled directly from the source code.
    atomscale.client
    atomscale.core.client
    atomscale.core.utils
+   atomscale.results.embeddings
    atomscale.results.rheed_image
    atomscale.results.rheed_video
    atomscale.results.xps
@@ -27,6 +28,7 @@ Reference documentation for modules pulled directly from the source code.
    _autosummary/atomscale.client
    _autosummary/atomscale.core.client
    _autosummary/atomscale.core.utils
+   _autosummary/atomscale.results.embeddings
    _autosummary/atomscale.results.rheed_image
    _autosummary/atomscale.results.rheed_video
    _autosummary/atomscale.results.xps

--- a/src/atomscale/client.py
+++ b/src/atomscale/client.py
@@ -575,13 +575,13 @@ class Client(BaseClient):
 
         # Responses may use camelCase keys; normalize to the snake_case column
         # names (snake_case keys pass through unchanged).
-        df = DataFrame(rows).rename(
+        matches = DataFrame(rows).rename(
             columns={"dataId": "data_id", "itemName": "item_name"}
         )
 
         # Always return exactly these columns: any missing one is filled with NA
         # and any extra fields are dropped, so empty and populated results match.
-        return df.reindex(columns=columns)
+        return matches.reindex(columns=columns)
 
     def get_rheed_timeseries(
         self,

--- a/src/atomscale/client.py
+++ b/src/atomscale/client.py
@@ -23,6 +23,7 @@ from atomscale.core.utils import _make_progress, normalize_path
 from atomscale.results import (
     ChangepointResult,
     EllipsometryResult,
+    EmbeddingsResult,
     MetrologyResult,
     OpticalResult,
     PhotoluminescenceResult,
@@ -42,6 +43,10 @@ from atomscale.timeseries.registry import get_provider
 TimeseriesDomain = Literal["rheed", "optical", "metrology"]
 
 _RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+# Fixed metric identifier the matches endpoint requires. Kept internal so callers
+# don't have to choose one; this value is available for effectively all RHEED data.
+_DEFAULT_SIMILARITY_METRIC = "specular_intensity"
 
 
 def _retry_client_call(
@@ -472,6 +477,188 @@ class Client(BaseClient):
             ts_df,
             workflow=workflow,
             window_span=window_span or 0.0,
+        )
+
+    def get_embeddings(
+        self,
+        data_id: str,
+        *,
+        workflow: str = "rheed_stationary",
+        window_span: float = 60.0,
+        kind: Literal["window", "prototype"] = "window",
+        offset: int = 0,
+        limit: int | None = None,
+    ) -> EmbeddingsResult:
+        """Fetch embedding vectors for a data entry.
+
+        Args:
+            data_id: Data ID to fetch embeddings for.
+            workflow: Similarity workflow name. Defaults to ``"rheed_stationary"``.
+            window_span: Window span in seconds. Defaults to ``60.0``.
+            kind: ``"window"`` for one time-resolved vector per window (with
+                ``real_times`` / ``unix_times_ms``), or ``"prototype"`` for a small
+                set of representative vectors (with ``cluster_sizes``). Defaults to
+                ``"window"``.
+            offset: Number of leading vectors to skip. Defaults to ``0``.
+            limit: Maximum number of vectors to return. ``None`` (default) returns
+                all available vectors.
+
+        Returns:
+            EmbeddingsResult: The embedding vectors and associated metadata. When
+            no embeddings are available for this data (workflow / window span), a
+            :class:`UserWarning` is emitted and an empty result is returned, so
+            loops over many IDs don't crash. ``result.count`` is the total number
+            of vectors available before ``offset`` / ``limit``; the number actually
+            returned is ``len(result.vectors)``.
+        """
+        payload: dict | None = self._get(  # type: ignore[assignment]
+            sub_url=f"similarity/{workflow}/{data_id}/embeddings/",
+            params={
+                "window_span": window_span,
+                "kind": kind,
+                "offset": offset,
+                "limit": limit,
+            },
+        )
+        return EmbeddingsResult.from_api(
+            payload,
+            data_id=data_id,
+            workflow=workflow,
+            kind=kind,
+            window_span=window_span,
+        )
+
+    def get_similarity_matches(
+        self,
+        source_id: str,
+        *,
+        workflow: str = "rheed_stationary",
+        window_span: float = 60.0,
+        live_comparison: bool = False,
+        limit: int | None = None,
+    ) -> DataFrame:
+        """Fetch the top similarity matches for a source data entry.
+
+        Args:
+            source_id: Data ID (or physical sample ID) to find matches for.
+            workflow: Similarity workflow name. Defaults to ``"rheed_stationary"``.
+            window_span: Window span in seconds. Defaults to ``60.0``.
+            live_comparison: When ``True``, also include the source entry's most
+                recent (still-streaming) data in the comparison. Defaults to ``False``.
+            limit: Maximum number of matches to return. ``None`` (default) uses the
+                server default.
+
+        Returns:
+            DataFrame: Columns ``["data_id", "item_name", "similarity"]``, one row
+            per match. Empty (with those columns) when there are no matches or the
+            source is not found.
+        """
+        payload = self._get(
+            sub_url=f"similarity/{workflow}/{source_id}/matches/",
+            params={
+                "metric": _DEFAULT_SIMILARITY_METRIC,
+                "windowSpan": window_span,
+                "usePrototypes": True,
+                "liveComparison": live_comparison,
+                "limit": limit,
+            },
+        )
+
+        columns = ["data_id", "item_name", "similarity"]
+        if not payload:
+            rows: list[dict] = []
+        elif isinstance(payload, dict):
+            # Tolerate a wrapped ``{"matches": [...]}`` shape.
+            rows = payload.get("matches", []) or []
+        else:
+            rows = payload
+
+        # Responses may use camelCase keys; normalize to the snake_case column
+        # names (snake_case keys pass through unchanged).
+        df = DataFrame(rows).rename(
+            columns={"dataId": "data_id", "itemName": "item_name"}
+        )
+
+        # Always return exactly these columns: any missing one is filled with NA
+        # and any extra fields are dropped, so empty and populated results match.
+        return df.reindex(columns=columns)
+
+    def get_rheed_timeseries(
+        self,
+        data_id: str,
+        *,
+        property_names: list[str] | None = None,
+        include_low_level_features: bool = False,
+        last_n: int | None = None,
+        elapsed_seconds: float | None = None,
+    ) -> DataFrame:
+        """Fetch the RHEED feature timeseries for a data entry.
+
+        Unlike :meth:`get`, which returns only the standard feature set, this
+        method can also return the full set of low-level features and filter which
+        points are returned.
+
+        Args:
+            data_id: Data ID of the RHEED video.
+            property_names: Restrict the result to these feature names. These are
+                the underlying property names (e.g. ``specular_intensity``,
+                ``referenced_strain``), which may differ from the display column
+                names in the returned DataFrame. ``None`` (default) returns the
+                standard set.
+            include_low_level_features: When ``True``, include the full set of
+                low-level per-point features as additional columns. Defaults to
+                ``False``.
+            last_n: If set, only return the last ``N`` points.
+            elapsed_seconds: If set, only return points within the last
+                ``elapsed_seconds`` of the recording.
+
+        Returns:
+            DataFrame: The RHEED timeseries, indexed by ``["Angle", "Frame Number"]``
+            when available. Low-level feature columns are included when
+            ``include_low_level_features=True``.
+        """
+        provider = get_provider("rheed")
+        raw = provider.fetch_raw(
+            self,
+            data_id,
+            include_low_level_features=include_low_level_features,
+            property_names=property_names,
+            last_n=last_n,
+            elapsed_seconds=elapsed_seconds,
+        )
+        return provider.to_dataframe(raw)
+
+    def get_frame(
+        self,
+        data_id: str,
+        *,
+        frame_index: int = 0,
+    ) -> RHEEDImageResult | None:
+        """Fetch a single extracted RHEED frame as a :class:`RHEEDImageResult`.
+
+        Args:
+            data_id: Data ID of the RHEED video.
+            frame_index: Index into the video's extracted-frame list (supports
+                negative indexing). Defaults to ``0`` (first extracted frame).
+
+        Returns:
+            RHEEDImageResult | None: The frame's image result, or ``None`` if the
+            video has no extracted frames, ``frame_index`` is out of range, or the
+            selected frame has no image.
+        """
+        provider = get_provider("rheed")
+        frames_payload: dict | None = self._get(  # type: ignore[assignment]
+            sub_url=provider.snapshot_url(data_id)
+        )
+        frames = (frames_payload or {}).get("frames", [])
+        if not frames or not (-len(frames) <= frame_index < len(frames)):
+            return None
+
+        frame = frames[frame_index]
+        metadata = {k: v for k, v in frame.items() if k == "timestamp_seconds"}
+        # Returns None when the selected frame has no associated image.
+        return provider.fetch_snapshot(
+            self, {"image_uuid": frame.get("image_uuid"), "metadata": metadata}
         )
 
     def iter_poll_similarity_trajectory(

--- a/src/atomscale/results/__init__.py
+++ b/src/atomscale/results/__init__.py
@@ -1,5 +1,6 @@
 from .changepoint import ChangepointResult
 from .ellipsometry import EllipsometryResult
+from .embeddings import EmbeddingsResult
 from .group import PhysicalSampleResult, ProjectResult
 from .metrology import MetrologyResult
 from .optical import OpticalResult
@@ -15,6 +16,7 @@ from .xrd import XRDResult
 __all__ = [
     "ChangepointResult",
     "EllipsometryResult",
+    "EmbeddingsResult",
     "MetrologyResult",
     "OpticalResult",
     "PhotoluminescenceResult",

--- a/src/atomscale/results/changepoint.py
+++ b/src/atomscale/results/changepoint.py
@@ -28,14 +28,14 @@ class ChangepointResult(MSONable):
         Args:
             id (UUID | str): Unique ID of the changepoint record.
             data_id (UUID | str): Data ID in the catalogue this changepoint was detected on.
-            data_modality (str): Source/workflow value the changepoint came from (e.g. "rheed_stationary").
+            data_modality (str): The data modality the changepoint was detected in (e.g. "rheed_stationary").
             property_name (str): Property/channel on which the changepoint was detected.
             severity (str): One of "info", "warning", "critical".
             score (float): Normalized changepoint score in [0, 1].
             window_start_elapsed (float): Start of the changepoint window, seconds from timeseries start.
             window_end_elapsed (float): End of the changepoint window, seconds from timeseries start.
             detection_method (str): One of "forecasting", "clustering", "intensity_profile".
-            detail (dict): Method-specific metadata.
+            detail (dict): Additional details about the changepoint; the available keys depend on the detection_method used.
             label (str | None): Applied category label, if any.
         """
         self.id = id

--- a/src/atomscale/results/embeddings.py
+++ b/src/atomscale/results/embeddings.py
@@ -1,0 +1,176 @@
+"""Result object for similarity embedding vectors."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+from uuid import UUID
+
+import numpy as np
+from monty.json import MSONable
+from numpy.typing import NDArray
+
+
+class EmbeddingsResult(MSONable):
+    """Embedding vectors for a single data entry.
+
+    Returned by :meth:`atomscale.Client.get_embeddings`. The vectors are held as
+    a dense ``(n_returned, dimension)`` float array in :attr:`vectors`, with
+    parallel metadata arrays. The two ``kind`` variants carry different metadata:
+
+    - ``kind="window"``: one time-resolved vector per window. :attr:`real_times`
+      (relative seconds) and :attr:`unix_times_ms` (absolute milliseconds) give
+      the point in time each vector corresponds to.
+    - ``kind="prototype"``: a small set of representative vectors.
+      :attr:`cluster_sizes` gives how many windows each one summarizes.
+
+    Metadata arrays not relevant to the returned ``kind`` are ``None``.
+
+    Attributes:
+        data_id (UUID | str): Data ID the embeddings were computed for.
+        workflow (str): Similarity workflow name (e.g. ``"rheed_stationary"``).
+        kind (str): ``"window"`` or ``"prototype"``.
+        window_span (float): Window span (seconds) the vectors were computed at.
+        vectors (NDArray): ``(n_returned, dimension)`` array of embedding vectors,
+            where ``n_returned == len(vectors)``.
+        dimension (int): Length of each embedding vector (``0`` when the result is empty).
+        count (int): Total vectors available for this ``data_id`` *before*
+            ``offset``/``limit`` — may exceed ``len(vectors)``. The number
+            actually returned is ``len(vectors)``.
+        offset (int): Number of leading vectors skipped (window kind).
+        truncated (bool): True when more vectors are available than were returned,
+            so the result is incomplete.
+        real_times (NDArray | None): ``(n_returned,)`` relative time in seconds (window kind).
+        unix_times_ms (NDArray | None): ``(n_returned,)`` absolute unix time in ms (window kind).
+        cluster_sizes (NDArray | None): ``(n_returned,)`` windows summarized per vector (prototype kind).
+    """
+
+    def __init__(
+        self,
+        data_id: UUID | str,
+        workflow: str,
+        kind: str,
+        window_span: float,
+        vectors: NDArray,
+        dimension: int,
+        count: int,
+        truncated: bool,
+        offset: int = 0,
+        real_times: NDArray | None = None,
+        unix_times_ms: NDArray | None = None,
+        cluster_sizes: NDArray | None = None,
+    ):
+        self.data_id = data_id
+        self.workflow = workflow
+        self.kind = kind
+        self.window_span = window_span
+        self.vectors = vectors
+        self.dimension = dimension
+        self.count = count
+        self.offset = offset
+        self.truncated = truncated
+        self.real_times = real_times
+        self.unix_times_ms = unix_times_ms
+        self.cluster_sizes = cluster_sizes
+
+    def __repr__(self) -> str:
+        return (
+            f"EmbeddingsResult(data_id={self.data_id!r}, kind={self.kind!r}, "
+            f"returned={len(self.vectors)}, count={self.count}, "
+            f"dimension={self.dimension}, truncated={self.truncated})"
+        )
+
+    @staticmethod
+    def _point_column(
+        points: list[dict[str, Any]], key: str, *, integer: bool
+    ) -> NDArray | None:
+        """Collect ``point[key]`` across ``points`` into an array (``None`` if all absent).
+
+        Returns an ``int64`` array for integer columns when every value is
+        present; otherwise a ``float64`` array with ``NaN`` for missing entries
+        (``int64`` cannot represent a null). Used for the per-kind metadata
+        columns (``real_time_seconds``/``unix_time_ms``/``cluster_size``), which
+        the endpoint only populates for the matching ``kind``.
+        """
+        values = [p.get(key) for p in points]
+        if all(v is None for v in values):
+            return None
+        if integer and all(v is not None for v in values):
+            return np.asarray(values, dtype=np.int64)
+        return np.asarray(
+            [np.nan if v is None else v for v in values], dtype=np.float64
+        )
+
+    @classmethod
+    def from_api(
+        cls,
+        payload: dict[str, Any] | None,
+        *,
+        data_id: UUID | str,
+        workflow: str,
+        kind: str,
+        window_span: float,
+    ) -> EmbeddingsResult:
+        """Build an :class:`EmbeddingsResult` from a raw endpoint payload.
+
+        When no embeddings are available for the given workflow / window span,
+        this emits a :class:`UserWarning` and returns an empty result so loops
+        over many IDs don't crash.
+        """
+        payload = payload or {}
+        points: list[dict[str, Any]] = payload.get("points") or []
+
+        # The endpoint echoes kind/window_span; prefer them, fall back to request.
+        resolved_kind = payload.get("kind", kind)
+        resolved_span = payload.get("window_span", window_span)
+
+        if not points:
+            warnings.warn(
+                f"No embeddings returned for data_id {data_id!r} (workflow "
+                f"{workflow!r}, kind {resolved_kind!r}, window_span "
+                f"{resolved_span}). The entry may not be embedded for this "
+                "workflow/window span.",
+                stacklevel=2,
+            )
+            return cls(
+                data_id=data_id,
+                workflow=workflow,
+                kind=resolved_kind,
+                window_span=resolved_span,
+                vectors=np.empty((0, 0), dtype=np.float64),
+                dimension=int(payload.get("dimension") or 0),
+                count=int(payload.get("count", 0)),
+                offset=int(payload.get("offset", 0)),
+                truncated=bool(payload.get("truncated", False)),
+            )
+
+        try:
+            vectors = np.asarray([p["vector"] for p in points], dtype=np.float64)
+            if vectors.ndim != 2:
+                raise ValueError(f"expected 2-D vectors, got shape {vectors.shape}")
+        except (ValueError, KeyError, TypeError) as exc:
+            raise ValueError(
+                f"Malformed embeddings payload for data_id {data_id!r} "
+                f"(workflow {workflow!r}, kind {resolved_kind!r}): could not build "
+                f"a numeric (count, dimension) array from the point vectors "
+                f"(likely ragged or non-numeric). {exc}"
+            ) from exc
+
+        declared_dim = payload.get("dimension")
+        dimension = int(declared_dim) if declared_dim else int(vectors.shape[1])
+        count = int(payload.get("count", vectors.shape[0]))
+
+        return cls(
+            data_id=data_id,
+            workflow=workflow,
+            kind=resolved_kind,
+            window_span=resolved_span,
+            vectors=vectors,
+            dimension=dimension,
+            count=count,
+            offset=int(payload.get("offset", 0)),
+            truncated=bool(payload.get("truncated", False)),
+            real_times=cls._point_column(points, "real_time_seconds", integer=False),
+            unix_times_ms=cls._point_column(points, "unix_time_ms", integer=True),
+            cluster_sizes=cls._point_column(points, "cluster_size", integer=True),
+        )

--- a/src/atomscale/results/embeddings.py
+++ b/src/atomscale/results/embeddings.py
@@ -130,7 +130,7 @@ class EmbeddingsResult(MSONable):
                 f"{workflow!r}, kind {resolved_kind!r}, window_span "
                 f"{resolved_span}). The entry may not be embedded for this "
                 "workflow/window span.",
-                stacklevel=2,
+                stacklevel=3,
             )
             return cls(
                 data_id=data_id,

--- a/src/atomscale/results/optical.py
+++ b/src/atomscale/results/optical.py
@@ -26,6 +26,9 @@ class OpticalResult(MSONable):
         Args:
             data_id (UUID | str): Data ID for the entry in the data catalogue.
             timeseries_data (DataFrame): Pandas DataFrame with timeseries data associated with the video.
+            snapshot_image_data (list[OpticalImageResult] | None): Snapshot images captured during the
+                measurement, or None if no snapshots are available. Each item provides its ``.data_id``
+                and its ``.processed_image`` (a PIL Image).
             collected_datetime (str | None): Datetime when the data was collected.
         """
         self.data_id = data_id

--- a/src/atomscale/results/photoluminescence.py
+++ b/src/atomscale/results/photoluminescence.py
@@ -27,7 +27,7 @@ class PhotoluminescenceResult(MSONable):
             photoluminescence_id: Unique identifier for the photoluminescence result.
             energies: Energy axis values.
             intensities: Intensity values aligned with `energies`.
-            detected_peaks: Optional mapping of peak labels to positions/metadata.
+            detected_peaks: Optional mapping of detected-peak labels to each peak's value, where a value is either a numeric position along the energy axis (float) or a descriptive string (str).
             last_updated: Optional last-updated timestamp string.
             collected_datetime: Datetime when the data was collected.
         """

--- a/src/atomscale/results/raman.py
+++ b/src/atomscale/results/raman.py
@@ -27,7 +27,7 @@ class RamanResult(MSONable):
             raman_id: Unique identifier for the Raman result.
             raman_shift: Raman shift axis values.
             intensities: Intensity values aligned with `raman_shift`.
-            detected_peaks: Optional mapping of peak labels to positions/metadata.
+            detected_peaks: Optional mapping of detected peak labels (keys) to their values, where each value is either the peak position (a Raman shift value, as a float) or a descriptive string.
             last_updated: Optional last-updated timestamp string.
             collected_datetime: Datetime when the data was collected.
         """

--- a/src/atomscale/results/rheed_image.py
+++ b/src/atomscale/results/rheed_image.py
@@ -740,8 +740,10 @@ def _get_rheed_image_result(
     )
 
     # Get mask data
-    mask_data: dict = client._get(sub_url=f"rheed/images/{data_id}/mask")  # type: ignore  #noqa: PGH003
-    mask_rle = mask_data.get("mask_rle")
+    mask_data: dict | None = client._get(sub_url=f"rheed/images/{data_id}/mask")  # type: ignore  #noqa: PGH003
+    # The mask endpoint 404s (→ None) for frames without a segmentation mask,
+    # so guard the .get() rather than dereferencing a possibly-None payload.
+    mask_rle = mask_data.get("mask_rle") if mask_data is not None else None
     mask_array = None
 
     if mask_data is not None and mask_rle is not None:

--- a/src/atomscale/results/rheed_image.py
+++ b/src/atomscale/results/rheed_image.py
@@ -20,7 +20,6 @@ from pycocotools import mask as mask_util
 from atomscale.core import BaseClient, boxes_overlap, generate_graph_from_nodes
 
 tp.quiet()
-# test comment
 
 
 class RHEEDImageResult(MSONable):
@@ -68,6 +67,8 @@ class RHEEDImageResult(MSONable):
         Args:
             show_mask (bool): Whether to show mask overlay of identified pattern. Defaults to True.
             show_spot_nodes (bool): Whether to show identified diffraction node overlays. Defaults to True.
+            symmetrize (bool): Whether to mirror the pattern across the vertical axis before drawing overlays. Defaults to False.
+            alpha (float): Opacity of the mask overlay, from 0 (transparent) to 1 (opaque). Defaults to 0.2.
 
         Returns:
             (Image): PIL Image object with optional overlays
@@ -196,16 +197,17 @@ class RHEEDImageResult(MSONable):
         symmetrize: bool = False,
         return_as_features: bool = False,
     ) -> pd.DataFrame:
-        """Featurize the RHEED image collection into a dataframe of node features and edge features.
+        """Featurize this RHEED image into a DataFrame of per-node features.
 
         Args:
             extra_data (dict | None): Dictionary containing field names and values of extra data to be included in the DataFrame object.
                 Defaults to None.
             symmetrize (bool): Whether to symmetrize the data across the vertical axis. Defaults to False.
-            return_as_features (bool): Whether to return a feature-foward version of the DataFrame. Defaults to False.
+            return_as_features (bool): When True, return a wide feature table with one row per image and
+                one column per (feature, node) pair; when False, return the raw per-node rows. Defaults to False.
 
         Returns:
-            (DataFrame): Pandas DataFrame object of RHEED node and edge features.
+            (DataFrame): Pandas DataFrame of per-node features.
         """
 
         extra_data = extra_data or {}
@@ -555,7 +557,8 @@ class RHEEDImageCollection(MSONable):
         features across RHEED patterns, based on relative position to the center feature.
 
         Returns:
-            (tuple[DataFrame, list[RHEEDImageResult]): Pandas DataFrame object with aligned RHEED fingerprint data
+            (RHEEDImageCollection): A new collection whose RHEED fingerprints have had their nodes
+                relabeled so that matching scattering features share the same node ID across images.
         """
 
         image_scales = [
@@ -617,17 +620,18 @@ class RHEEDImageCollection(MSONable):
         symmetrize: bool = False,
         return_as_features: bool = True,
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """Featurize the RHEED image collection into a dataframe of node features and edge features.
+        """Featurize the RHEED image collection into a DataFrame of per-node features across all images.
 
         Args:
             streamline (bool): Whether to streamline the DataFrame object and remove null values. Defaults to True.
             normalize (bool): Whether to min/max normalize the feature data across all images. Defaults to True.
-            symmetrize (bool): Whether to symmetrize the RHEEED images and segmented patterns about the vertical axis before
+            symmetrize (bool): Whether to symmetrize the RHEED images and segmented patterns about the vertical axis before
                 obtaining the DataFrame representation. Defaults to False.
-            return_as_features (bool): Whether to return the final feature-forward DataFrame. Defaults to True.
+            return_as_features (bool): When True, return a wide feature table (one column per feature/node);
+                when False, return the raw per-node rows. Defaults to True.
 
         Returns:
-            (DataFrame): Pandas DataFrame object of RHEED node and edge features.
+            (DataFrame): Pandas DataFrame of per-node features across all images.
         """
 
         node_feature_cols = [

--- a/src/atomscale/results/rheed_video.py
+++ b/src/atomscale/results/rheed_video.py
@@ -23,11 +23,13 @@ class RHEEDVideoResult(MSONable):
 
         Args:
             data_id (UUID | str): Data ID for the entry in the data catalogue.
-            timeseries_data (DataFrame): Pandas DataFrame with timeseries data associated with the video.
-                Includes cluster assignments, specular intensity, strain, etc...
-            snapshot_image_data (list[atomscale.results.rheed_image.RHEEDImageResult]): List of
-                :class:`atomscale.results.rheed_image.RHEEDImageResult` objects containing data for images associated
-                with each user extracted snapshot in the video.
+            timeseries_data (DataFrame): Pandas DataFrame with per-frame RHEED features, indexed
+                against a "Time" column. Columns are capitalized labels such as "Cluster ID",
+                "Specular Intensity", "Strain", "Cumulative Strain", "Oscillation Period",
+                "Diffraction Spot Count", and "Lattice Spacing".
+            snapshot_image_data (list[atomscale.results.rheed_image.RHEEDImageResult] | None): One
+                :class:`atomscale.results.rheed_image.RHEEDImageResult` per snapshot extracted from the
+                video, or None if no snapshots were extracted.
             rotating (bool): Whether the video was taken of a rotating stage.
             collected_datetime (str | None): Datetime when the data was collected.
         """

--- a/src/atomscale/results/similarity_trajectory.py
+++ b/src/atomscale/results/similarity_trajectory.py
@@ -21,8 +21,9 @@ class SimilarityTrajectoryResult(MSONable):
         Args:
             source_id (UUID | str): Source ID for the similarity trajectory query.
             workflow (str): Workflow name used for the similarity analysis.
-            window_span (float): Window span parameter used for the trajectory.
-            timeseries_data (DataFrame): Pandas DataFrame with similarity trajectory data.
+            window_span (float): Length of the time window, in seconds, used when computing the similarity trajectory.
+            timeseries_data (DataFrame): Similarity over time, indexed by ("Reference ID", "Time")
+                with columns "Similarity", "Reference Name", "UNIX Timestamp", "Active", and "Averaged Count".
             source_data_ids (Sequence[UUID | str] | None): Sequence of source data IDs included in the trajectory.
         """
         self.source_id = source_id

--- a/src/atomscale/results/unknown.py
+++ b/src/atomscale/results/unknown.py
@@ -9,8 +9,8 @@ from monty.json import MSONable
 class UnknownResult(MSONable):
     """Fallback result for unsupported or unknown data types.
 
-    Stores minimal information from the data catalogue so callers can
-    still inspect the entry even when no domain-specific handler exists.
+    Stores minimal information from the data catalogue so callers can still
+    inspect the entry even when the data type is not specifically supported.
     """
 
     def __init__(
@@ -28,7 +28,13 @@ class UnknownResult(MSONable):
         self.collected_datetime = collected_datetime
 
     def summary(self) -> dict[str, Any]:
-        """Return a lightweight summary of catalogue fields if present."""
+        """Return the subset of catalogue fields useful for a quick overview.
+
+        Returns a dict containing whichever of these are present in the catalogue
+        entry: ``raw_name``, ``pipeline_status``, ``raw_file_type``,
+        ``upload_datetime``, ``last_updated``, ``char_source_type``,
+        ``physical_sample_id``, and ``project_ids``.
+        """
 
         keys_of_interest = (
             "raw_name",

--- a/src/atomscale/results/xps.py
+++ b/src/atomscale/results/xps.py
@@ -30,7 +30,9 @@ class XPSResult(MSONable):
             intensities (list[float]): List of intensity values.
             predicted_composition (dict[str, float]): Mapping between element symbols and
                 predicted fractional composition values.
-            detected_peaks (dict[str, float | str]): Mapping with peak transition labels.
+            detected_peaks (dict[str, float | str]): Mapping from detected peak transition labels
+                (e.g. "C 1s", "O 1s") to each peak's binding energy position in eV, or to a string
+                annotation of that peak.
             elements_manually_set (bool): Whether the elements represented in the predicted composition
                 were manually specified by the user.
             collected_datetime (str | None): Datetime when the data was collected.

--- a/src/atomscale/results/xrd.py
+++ b/src/atomscale/results/xrd.py
@@ -28,7 +28,7 @@ class XRDResult(MSONable):
         Args:
             data_id: Data catalogue identifier.
             xrd_id: Unique identifier for the XRD result.
-            two_theta: 2-theta angle values in degrees.
+            two_theta: 2-theta angle values, expressed in the unit given by `two_theta_unit` (degrees by default).
             intensities: Intensity values aligned with `two_theta`.
             detected_peaks: Optional list of detected peak dicts with keys
                 two_theta, intensity, d_spacing_angstrom, prominence, fwhm_degrees.

--- a/src/atomscale/timeseries/rheed.py
+++ b/src/atomscale/timeseries/rheed.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from pandas import DataFrame, concat
+from pandas import DataFrame, concat, json_normalize
 
 from atomscale.core import BaseClient
 from atomscale.results import (
@@ -53,6 +53,31 @@ class RHEEDProvider(TimeseriesProvider[RHEEDVideoResult]):
     def fetch_raw(self, client: BaseClient, data_id: str, **kwargs) -> Any:
         return client._get(sub_url=f"rheed/timeseries/{data_id}/", params=kwargs)
 
+    @staticmethod
+    def _flatten_low_level_features(df: DataFrame) -> DataFrame:
+        """Expand a ``low_level_features`` column of per-point dicts into columns.
+
+        Each point in the raw series may carry a ``low_level_features`` mapping
+        (present only when the timeseries was fetched with
+        ``include_low_level_features=True`` via
+        :meth:`atomscale.Client.get_rheed_timeseries`). This lifts those keys to
+        top-level columns — nested keys flattened with a dotted path — and drops
+        the original nested column. Points missing the mapping contribute NA for
+        those columns. Existing top-level columns win on name collision so known
+        metrics are never clobbered by a low-level feature of the same name.
+        """
+        normalized = df["low_level_features"].apply(
+            lambda v: v if isinstance(v, dict) else {}
+        )
+        expanded = json_normalize(normalized.tolist())
+        expanded.index = df.index
+
+        collisions = [c for c in expanded.columns if c in df.columns]
+        if collisions:
+            expanded = expanded.drop(columns=collisions)
+
+        return df.drop(columns=["low_level_features"]).join(expanded)
+
     def to_dataframe(self, raw: Any) -> DataFrame:
         if not raw:
             return DataFrame(None)
@@ -63,10 +88,15 @@ class RHEEDProvider(TimeseriesProvider[RHEEDVideoResult]):
             series = angle_block.get("series") or []
             if not series:
                 continue
+            angle_df = DataFrame(series)
+            # Flatten per-point low-level feature dicts into their own columns
+            # before the all-NA prune below so the pruning applies to them too.
+            if "low_level_features" in angle_df.columns:
+                angle_df = self._flatten_low_level_features(angle_df)
             # Drop columns that are all-NA within this angle block before concat;
             # otherwise pandas issues a FutureWarning about empty/all-NA entries
             # widening the result dtype.
-            angle_df = DataFrame(series).dropna(axis=1, how="all")
+            angle_df = angle_df.dropna(axis=1, how="all")
             angle_df["Angle"] = angle_block["angle"]
             frames.append(angle_df)
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,272 @@
+"""Unit tests for Client.get_embeddings and EmbeddingsResult.
+
+Payloads mirror the backend ``EmbeddingVectorsResponse`` / ``EmbeddingVectorPoint``
+models: a ``points`` list where each point carries a singular ``vector`` plus
+per-kind metadata (``real_time_seconds`` / ``unix_time_ms`` for window,
+``cluster_size`` for prototype), and top-level ``dimension`` / ``count`` /
+``offset`` / ``truncated``.
+"""
+
+import numpy as np
+import pytest
+
+from atomscale import Client
+from atomscale.results import EmbeddingsResult
+
+
+@pytest.fixture
+def client():
+    return Client(api_key="key_test", endpoint="http://example.com/")
+
+
+def _capturing_get(captured, payload):
+    def fake_get(sub_url, params=None, **kwargs):
+        captured["sub_url"] = sub_url
+        captured["params"] = params
+        return payload
+
+    return fake_get
+
+
+def _window_payload():
+    return {
+        "data_id": "data-1",
+        "workflow": "rheed_stationary",
+        "window_span": 60.0,
+        "kind": "window",
+        "dimension": 3,
+        "count": 2,
+        "offset": 0,
+        "truncated": True,
+        "points": [
+            {
+                "index": 0,
+                "vector": [1.0, 2.0, 3.0],
+                "real_time_seconds": 0.0,
+                "unix_time_ms": 1000.0,
+            },
+            {
+                "index": 1,
+                "vector": [4.0, 5.0, 6.0],
+                "real_time_seconds": 60.0,
+                "unix_time_ms": 61000.0,
+            },
+        ],
+    }
+
+
+def _prototype_payload():
+    return {
+        "data_id": "data-1",
+        "workflow": "rheed_stationary",
+        "window_span": 30.0,
+        "kind": "prototype",
+        "dimension": 2,
+        "count": 3,
+        "offset": 0,
+        "truncated": False,
+        "points": [
+            {"index": 0, "vector": [1.0, 2.0], "cluster_size": 10},
+            {"index": 1, "vector": [3.0, 4.0], "cluster_size": 5},
+            {"index": 2, "vector": [5.0, 6.0], "cluster_size": 2},
+        ],
+    }
+
+
+def test_get_embeddings_window(client, monkeypatch):
+    monkeypatch.setattr(client, "_get", _capturing_get({}, _window_payload()))
+
+    result = client.get_embeddings("data-1")
+
+    assert isinstance(result, EmbeddingsResult)
+    assert result.kind == "window"
+    assert result.workflow == "rheed_stationary"
+    assert result.vectors.shape == (2, 3)
+    assert result.dimension == 3
+    assert result.count == 2
+    assert result.truncated is True
+    np.testing.assert_array_equal(result.real_times, [0.0, 60.0])
+    np.testing.assert_array_equal(result.unix_times_ms, [1000, 61000])
+    assert result.unix_times_ms.dtype == np.int64
+    # window kind carries no cluster sizes
+    assert result.cluster_sizes is None
+
+
+def test_get_embeddings_prototype(client, monkeypatch):
+    monkeypatch.setattr(client, "_get", _capturing_get({}, _prototype_payload()))
+
+    result = client.get_embeddings("data-1", kind="prototype", window_span=30.0)
+
+    assert result.kind == "prototype"
+    assert result.vectors.shape == (3, 2)
+    np.testing.assert_array_equal(result.cluster_sizes, [10, 5, 2])
+    assert result.cluster_sizes.dtype == np.int64
+    # prototype kind carries no per-window times
+    assert result.real_times is None
+    assert result.unix_times_ms is None
+
+
+def test_get_embeddings_param_mapping(client, monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(client, "_get", _capturing_get(captured, _window_payload()))
+
+    client.get_embeddings(
+        "data-99",
+        workflow="custom_wf",
+        window_span=45.0,
+        kind="prototype",
+        offset=5,
+        limit=100,
+    )
+
+    assert captured["sub_url"] == "similarity/custom_wf/data-99/embeddings/"
+    assert captured["params"] == {
+        "window_span": 45.0,
+        "kind": "prototype",
+        "offset": 5,
+        "limit": 100,
+    }
+
+
+def test_get_embeddings_default_window_span_is_60(client, monkeypatch):
+    """SDK default is 60s (endpoint default is 30) and must be sent explicitly."""
+    captured: dict = {}
+    monkeypatch.setattr(client, "_get", _capturing_get(captured, _window_payload()))
+
+    client.get_embeddings("data-1")
+
+    assert captured["params"]["window_span"] == 60.0
+
+
+def test_get_embeddings_empty_warns(client, monkeypatch):
+    """A structured empty response (points=[]) means the entry isn't embedded."""
+    empty_payload = {
+        "data_id": "unembedded-id",
+        "workflow": "rheed_stationary",
+        "window_span": 60.0,
+        "kind": "window",
+        "dimension": None,
+        "count": 0,
+        "offset": 0,
+        "truncated": False,
+        "points": [],
+    }
+    monkeypatch.setattr(client, "_get", lambda *a, **k: empty_payload)
+
+    with pytest.warns(UserWarning, match="No embeddings returned"):
+        result = client.get_embeddings("unembedded-id")
+
+    assert result.count == 0
+    assert len(result.vectors) == 0
+    assert result.vectors.shape == (0, 0)
+    assert result.truncated is False
+
+
+def test_get_embeddings_none_response_warns(client, monkeypatch):
+    """A None response (404/empty body) is handled defensively without crashing."""
+    monkeypatch.setattr(client, "_get", lambda *a, **k: None)
+
+    with pytest.warns(UserWarning, match="No embeddings returned"):
+        result = client.get_embeddings("missing-id")
+
+    assert result.count == 0
+    assert len(result.vectors) == 0
+
+
+def test_count_is_total_available_and_offset_preserved():
+    """count reflects total-before-offset/limit; len(vectors) is what's returned."""
+    payload = {
+        "kind": "window",
+        "dimension": 2,
+        "count": 100,  # total available
+        "offset": 10,
+        "truncated": True,
+        "points": [
+            {
+                "index": 10,
+                "vector": [1.0, 2.0],
+                "real_time_seconds": 5.0,
+                "unix_time_ms": 5000.0,
+            },
+            {
+                "index": 11,
+                "vector": [3.0, 4.0],
+                "real_time_seconds": 6.0,
+                "unix_time_ms": 6000.0,
+            },
+        ],
+    }
+    result = EmbeddingsResult.from_api(
+        payload, data_id="d", workflow="w", kind="window", window_span=60.0
+    )
+    assert result.count == 100
+    assert result.offset == 10
+    assert len(result.vectors) == 2  # actually returned
+
+
+def test_from_api_infers_dimension_when_absent():
+    """dimension falls back to the vectors array shape when the server omits it."""
+    payload = {
+        "kind": "window",
+        "points": [
+            {
+                "index": 0,
+                "vector": [1.0, 2.0, 3.0],
+                "real_time_seconds": 0.0,
+                "unix_time_ms": 0.0,
+            },
+        ],
+    }
+    result = EmbeddingsResult.from_api(
+        payload, data_id="d", workflow="w", kind="window", window_span=60.0
+    )
+    assert result.dimension == 3
+
+
+def test_from_api_reads_window_span_and_kind_from_payload():
+    """The result reflects the echoed kind/window_span from the payload."""
+    payload = {
+        "kind": "prototype",
+        "window_span": 30.0,
+        "dimension": 1,
+        "count": 1,
+        "points": [{"index": 0, "vector": [1.0], "cluster_size": 7}],
+    }
+    result = EmbeddingsResult.from_api(
+        payload, data_id="d", workflow="w", kind="window", window_span=60.0
+    )
+    # Payload's authoritative values win over the request-time args.
+    assert result.kind == "prototype"
+    assert result.window_span == 30.0
+
+
+def test_from_api_empty_reads_metadata():
+    """Empty points with a populated body still surfaces dimension/truncated."""
+    payload = {
+        "kind": "window",
+        "dimension": None,
+        "count": 0,
+        "truncated": True,
+        "points": [],
+    }
+    with pytest.warns(UserWarning, match="No embeddings returned"):
+        result = EmbeddingsResult.from_api(
+            payload, data_id="d", workflow="w", kind="window", window_span=60.0
+        )
+    assert result.count == 0
+    assert result.dimension == 0
+    assert result.truncated is True
+
+
+def test_from_api_ragged_vectors_raises_clear_error():
+    payload = {
+        "kind": "window",
+        "points": [
+            {"index": 0, "vector": [1.0, 2.0, 3.0]},
+            {"index": 1, "vector": [4.0, 5.0]},  # ragged
+        ],
+    }
+    with pytest.raises(ValueError, match="Malformed embeddings payload"):
+        EmbeddingsResult.from_api(
+            payload, data_id="bad-id", workflow="w", kind="window", window_span=60.0
+        )

--- a/tests/test_rheed_image.py
+++ b/tests/test_rheed_image.py
@@ -1,11 +1,20 @@
+from io import BytesIO
+
 import pytest
 from pandas import DataFrame
+from PIL import Image as PILImage
 from PIL.Image import Image
 
 from atomscale import Client
 from atomscale.results import RHEEDImageResult
+from atomscale.results.rheed_image import _get_rheed_image_result
 
 from .conftest import ResultIDs
+
+# Fully-qualified target for the frame image builder as looked up inside the
+# RHEED provider (get_frame delegates to provider.fetch_snapshot, which calls
+# _get_rheed_image_result imported into the timeseries.rheed module namespace).
+_RHEED_IMAGE_BUILDER = "atomscale.timeseries.rheed._get_rheed_image_result"
 
 
 @pytest.fixture
@@ -123,3 +132,120 @@ def test_get_dataframe(result: RHEEDImageResult):
     df = result.get_pattern_dataframe(return_as_features=True)
     assert isinstance(df, DataFrame)
     assert len(df) == 1
+
+
+# --------------------------------------------------------------------------
+# Unit tests (no live API) for the missing-mask bugfix and get_frame.
+# --------------------------------------------------------------------------
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    PILImage.new("RGB", (4, 4), color=(10, 20, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_get_rheed_image_result_handles_missing_mask(monkeypatch):
+    """A 404 on the mask endpoint (→ None) must not raise (regression)."""
+    unit_client = Client(api_key="key_test", endpoint="http://example.com/")
+    png = _png_bytes()
+
+    def fake_get(sub_url, params=None, deserialize=True, base_override=None):
+        if base_override is not None:  # S3 image byte fetch
+            return png
+        if sub_url.endswith("/fingerprint"):
+            return None
+        if sub_url.endswith("/mask"):
+            return None  # <- previously triggered AttributeError on None.get()
+        if sub_url.startswith("data_entries/processed_data/"):
+            return {"url": "http://s3.example.com/image.png"}
+        return None
+
+    monkeypatch.setattr(unit_client, "_get", fake_get)
+
+    result = _get_rheed_image_result(unit_client, "frame-uuid")
+
+    assert isinstance(result, RHEEDImageResult)
+    assert result.mask is None
+    assert isinstance(result.processed_image, Image)
+
+
+def _two_frame_client(monkeypatch):
+    unit_client = Client(api_key="key_test", endpoint="http://example.com/")
+    monkeypatch.setattr(
+        unit_client,
+        "_get",
+        lambda *a, **k: {
+            "frames": [
+                {"image_uuid": "img-0", "timestamp_seconds": 1.0},
+                {"image_uuid": "img-1", "timestamp_seconds": 2.0},
+            ]
+        },
+    )
+    return unit_client
+
+
+def test_get_frame_returns_image_result(monkeypatch):
+    unit_client = _two_frame_client(monkeypatch)
+    sentinel = object()
+    captured: dict = {}
+
+    def fake_image_result(client=None, data_id=None, metadata=None):
+        captured["data_id"] = data_id
+        captured["metadata"] = metadata
+        return sentinel
+
+    monkeypatch.setattr(_RHEED_IMAGE_BUILDER, fake_image_result)
+
+    assert unit_client.get_frame("video-1", frame_index=1) is sentinel
+    assert captured["data_id"] == "img-1"
+    assert captured["metadata"] == {"timestamp_seconds": 2.0}
+
+
+def test_get_frame_negative_index_resolves_last_frame(monkeypatch):
+    unit_client = _two_frame_client(monkeypatch)
+    captured: dict = {}
+
+    def fake_image_result(client=None, data_id=None, metadata=None):
+        captured["data_id"] = data_id
+        return object()
+
+    monkeypatch.setattr(_RHEED_IMAGE_BUILDER, fake_image_result)
+
+    unit_client.get_frame("video-1", frame_index=-1)
+    assert captured["data_id"] == "img-1"
+
+
+def test_get_frame_missing_image_uuid_returns_none(monkeypatch):
+    unit_client = Client(api_key="key_test", endpoint="http://example.com/")
+    monkeypatch.setattr(
+        unit_client,
+        "_get",
+        lambda *a, **k: {"frames": [{"timestamp_seconds": 1.0}]},  # no image_uuid
+    )
+    called = {"n": 0}
+
+    def fake_image_result(**kwargs):
+        called["n"] += 1
+        return object()
+
+    monkeypatch.setattr(_RHEED_IMAGE_BUILDER, fake_image_result)
+
+    assert unit_client.get_frame("video-1", frame_index=0) is None
+    assert called["n"] == 0  # builder must not be invoked for an image-less frame
+
+
+def test_get_frame_out_of_range_returns_none(monkeypatch):
+    unit_client = Client(api_key="key_test", endpoint="http://example.com/")
+    monkeypatch.setattr(
+        unit_client,
+        "_get",
+        lambda *a, **k: {"frames": [{"image_uuid": "img-0"}]},
+    )
+    assert unit_client.get_frame("video-1", frame_index=5) is None
+
+
+def test_get_frame_no_frames_returns_none(monkeypatch):
+    unit_client = Client(api_key="key_test", endpoint="http://example.com/")
+    monkeypatch.setattr(unit_client, "_get", lambda *a, **k: None)
+    assert unit_client.get_frame("video-1") is None

--- a/tests/test_rheed_timeseries.py
+++ b/tests/test_rheed_timeseries.py
@@ -1,0 +1,184 @@
+"""Unit tests for Client.get_rheed_timeseries and low-level feature flattening."""
+
+import pytest
+from pandas import DataFrame
+
+from atomscale import Client
+from atomscale.timeseries.rheed import RHEEDProvider
+
+
+@pytest.fixture
+def client():
+    return Client(api_key="key_test", endpoint="http://example.com/")
+
+
+@pytest.fixture
+def provider():
+    return RHEEDProvider()
+
+
+def test_to_dataframe_flattens_low_level_features(provider):
+    raw = {
+        "series_by_angle": [
+            {
+                "angle": 0.0,
+                "series": [
+                    {
+                        "frame_number": 1,
+                        "specular_intensity": 100.0,
+                        "low_level_features": {"feat_a": 1.1, "feat_b": 2.2},
+                    },
+                    {
+                        "frame_number": 2,
+                        "specular_intensity": 110.0,
+                        "low_level_features": {"feat_a": 3.3, "feat_b": 4.4},
+                    },
+                ],
+            }
+        ]
+    }
+
+    df = provider.to_dataframe(raw)
+
+    assert "low_level_features" not in df.columns
+    assert "feat_a" in df.columns
+    assert "feat_b" in df.columns
+    assert df["feat_a"].tolist() == [1.1, 3.3]
+    assert df["feat_b"].tolist() == [2.2, 4.4]
+    # Known metric still renamed via RENAME_MAP.
+    assert "Specular Intensity" in df.columns
+
+
+def test_to_dataframe_flattens_nested_low_level_features(provider):
+    """Nested low-level feature dicts flatten with dotted-path column names."""
+    raw = {
+        "series_by_angle": [
+            {
+                "angle": 0.0,
+                "series": [
+                    {
+                        "frame_number": 1,
+                        "low_level_features": {"roi": {"x": 1.0, "y": 2.0}},
+                    }
+                ],
+            }
+        ]
+    }
+
+    df = provider.to_dataframe(raw)
+
+    assert "roi.x" in df.columns
+    assert "roi.y" in df.columns
+    assert "roi" not in df.columns
+    assert df["roi.x"].tolist() == [1.0]
+    assert df["roi.y"].tolist() == [2.0]
+
+
+def test_to_dataframe_low_level_features_missing_points(provider):
+    """Points lacking the mapping contribute NA for those columns."""
+    raw = {
+        "series_by_angle": [
+            {
+                "angle": 0.0,
+                "series": [
+                    {"frame_number": 1, "low_level_features": {"feat_a": 1.0}},
+                    {"frame_number": 2, "low_level_features": {}},
+                ],
+            }
+        ]
+    }
+
+    df = provider.to_dataframe(raw)
+
+    assert "feat_a" in df.columns
+    values = df["feat_a"].tolist()
+    assert values[0] == 1.0
+    assert values[1] != values[1]  # NaN
+
+
+def test_to_dataframe_without_low_level_features_unchanged(provider):
+    raw = {
+        "series_by_angle": [
+            {"angle": 0.0, "series": [{"frame_number": 1, "specular_intensity": 100.0}]}
+        ]
+    }
+
+    df = provider.to_dataframe(raw)
+
+    assert "low_level_features" not in df.columns
+    assert "Specular Intensity" in df.columns
+
+
+def test_low_level_feature_does_not_clobber_known_column(provider):
+    """A low-level feature colliding with a top-level key must not overwrite it."""
+    raw = {
+        "series_by_angle": [
+            {
+                "angle": 0.0,
+                "series": [
+                    {
+                        "frame_number": 1,
+                        "specular_intensity": 100.0,
+                        "low_level_features": {"specular_intensity": 999.0},
+                    }
+                ],
+            }
+        ]
+    }
+
+    df = provider.to_dataframe(raw)
+
+    # Top-level value wins; renamed to "Specular Intensity".
+    assert df["Specular Intensity"].tolist() == [100.0]
+
+
+def test_get_rheed_timeseries_forwards_params(client, monkeypatch):
+    captured: dict = {}
+
+    def fake_get(sub_url, params=None, **kwargs):
+        captured["sub_url"] = sub_url
+        captured["params"] = params
+        return {
+            "series_by_angle": [
+                {
+                    "angle": 0.0,
+                    "series": [
+                        {"frame_number": 1, "low_level_features": {"raw_x": 5.0}}
+                    ],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(client, "_get", fake_get)
+
+    df = client.get_rheed_timeseries(
+        "video-1",
+        property_names=["specular_intensity", "spot_count"],
+        include_low_level_features=True,
+        last_n=50,
+        elapsed_seconds=30.0,
+    )
+
+    assert captured["sub_url"] == "rheed/timeseries/video-1/"
+    assert captured["params"] == {
+        "include_low_level_features": True,
+        "property_names": ["specular_intensity", "spot_count"],
+        "last_n": 50,
+        "elapsed_seconds": 30.0,
+    }
+    assert isinstance(df, DataFrame)
+    assert "raw_x" in df.columns
+
+
+def test_get_rheed_timeseries_defaults(client, monkeypatch):
+    captured: dict = {}
+
+    def fake_get(sub_url, params=None, **kwargs):
+        captured["params"] = params
+        return None
+
+    monkeypatch.setattr(client, "_get", fake_get)
+    client.get_rheed_timeseries("video-1")
+
+    assert captured["params"]["include_low_level_features"] is False
+    assert captured["params"]["property_names"] is None

--- a/tests/test_similarity_matches.py
+++ b/tests/test_similarity_matches.py
@@ -1,0 +1,166 @@
+"""Unit tests for Client.get_similarity_matches."""
+
+import pytest
+from pandas import DataFrame
+
+from atomscale import Client
+from atomscale.client import _DEFAULT_SIMILARITY_METRIC
+
+
+@pytest.fixture
+def client():
+    return Client(api_key="key_test", endpoint="http://example.com/")
+
+
+def test_matches_sends_camelcase_chamfer_params(client, monkeypatch):
+    """The simplified method fixes metric/usePrototypes and sends camelCase params."""
+    captured: dict = {}
+
+    def fake_get(sub_url, params=None, **kwargs):
+        captured["sub_url"] = sub_url
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(client, "_get", fake_get)
+
+    client.get_similarity_matches(
+        "source-1",
+        workflow="rheed_stationary",
+        window_span=45.0,
+        live_comparison=True,
+        limit=25,
+    )
+
+    assert captured["sub_url"] == "similarity/rheed_stationary/source-1/matches/"
+    assert captured["params"] == {
+        "metric": _DEFAULT_SIMILARITY_METRIC,
+        "windowSpan": 45.0,
+        "usePrototypes": True,
+        "liveComparison": True,
+        "limit": 25,
+    }
+    # Removed knobs must not leak into the query.
+    assert "refine" not in captured["params"]
+    assert "returnNullIf404" not in captured["params"]
+
+
+def test_matches_defaults(client, monkeypatch):
+    """Defaults hit the chamfer path: prototypes on, window_span 60, fixed metric."""
+    captured: dict = {}
+
+    def fake_get(sub_url, params=None, **kwargs):
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(client, "_get", fake_get)
+    client.get_similarity_matches("source-1")
+
+    assert captured["params"]["usePrototypes"] is True
+    assert captured["params"]["windowSpan"] == 60.0
+    assert captured["params"]["metric"] == _DEFAULT_SIMILARITY_METRIC
+    assert captured["params"]["liveComparison"] is False
+
+
+def test_matches_dataframe_shape(client, monkeypatch):
+    # Backend serializes SimilarityMatchResponse by alias (camelCase on the wire),
+    # and includes extra fields (workflow, profile, image) the SDK drops.
+    payload = [
+        {
+            "workflow": "rheed_stationary",
+            "dataId": "a",
+            "itemName": "Sample A",
+            "similarity": 0.95,
+            "profile": [0.1],
+            "image": None,
+        },
+        {
+            "workflow": "rheed_stationary",
+            "dataId": "b",
+            "itemName": "Sample B",
+            "similarity": 0.80,
+            "profile": [0.2],
+            "image": None,
+        },
+    ]
+    monkeypatch.setattr(client, "_get", lambda *a, **k: payload)
+
+    df = client.get_similarity_matches("source-1")
+
+    assert isinstance(df, DataFrame)
+    assert list(df.columns) == ["data_id", "item_name", "similarity"]
+    assert len(df) == 2
+    assert df.iloc[0]["data_id"] == "a"
+    assert df.iloc[0]["item_name"] == "Sample A"
+    assert df.iloc[0]["similarity"] == 0.95
+
+
+def test_matches_empty_returns_empty_frame_with_columns(client, monkeypatch):
+    monkeypatch.setattr(client, "_get", lambda *a, **k: None)
+
+    df = client.get_similarity_matches("source-1")
+
+    assert isinstance(df, DataFrame)
+    assert len(df) == 0
+    assert list(df.columns) == ["data_id", "item_name", "similarity"]
+
+
+def test_matches_tolerates_wrapped_payload(client, monkeypatch):
+    payload = {"matches": [{"dataId": "a", "itemName": "A", "similarity": 0.5}]}
+    monkeypatch.setattr(client, "_get", lambda *a, **k: payload)
+
+    df = client.get_similarity_matches("source-1")
+
+    assert len(df) == 1
+    assert df.iloc[0]["data_id"] == "a"
+
+
+def test_matches_enforces_exact_three_columns(client, monkeypatch):
+    """camelCase aliases are renamed, extra fields dropped, column order enforced."""
+    payload = [
+        # camelCase wire keys, out of canonical order, with extra backend fields
+        {
+            "similarity": 0.9,
+            "profile": [0.1],
+            "workflow": "wf",
+            "itemName": "A",
+            "dataId": "a",
+        },
+    ]
+    monkeypatch.setattr(client, "_get", lambda *a, **k: payload)
+
+    df = client.get_similarity_matches("source-1")
+
+    assert list(df.columns) == ["data_id", "item_name", "similarity"]
+    assert df.iloc[0]["data_id"] == "a"
+    assert df.iloc[0]["item_name"] == "A"
+    assert df.iloc[0]["similarity"] == 0.9
+
+
+def test_matches_missing_item_name_filled_na(client, monkeypatch):
+    """A match without itemName still yields all three columns (item_name NA)."""
+    payload = [{"dataId": "a", "similarity": 0.9}]  # itemName omitted
+    monkeypatch.setattr(client, "_get", lambda *a, **k: payload)
+
+    df = client.get_similarity_matches("source-1")
+
+    assert list(df.columns) == ["data_id", "item_name", "similarity"]
+    assert df.iloc[0]["data_id"] == "a"
+    assert df["item_name"].isna().all()
+
+
+def test_matches_tolerates_snake_case_keys(client, monkeypatch):
+    """If the backend ever stops aliasing, snake_case keys pass through unchanged."""
+    payload = [{"data_id": "a", "item_name": "A", "similarity": 0.9}]
+    monkeypatch.setattr(client, "_get", lambda *a, **k: payload)
+
+    df = client.get_similarity_matches("source-1")
+
+    assert list(df.columns) == ["data_id", "item_name", "similarity"]
+    assert df.iloc[0]["data_id"] == "a"
+
+
+def test_matches_rejects_removed_kwargs(client):
+    """The removed knobs are no longer accepted."""
+    for bad_kwarg in ("metric", "use_prototypes", "refine", "return_null_if_404"):
+        with pytest.raises(TypeError):
+            client.get_similarity_matches("source-1", **{bad_kwarg: True})  # type: ignore[arg-type]


### PR DESCRIPTION
Adds SDK support for the new embedding/similarity backend endpoints, plus a RHEED fix and docs cleanup.

- `Client.get_embeddings(...)` — fetch window- or prototype-level embedding vectors as a new `EmbeddingsResult` (`.vectors`, `.dimension`, `.count`, `.real_times`/`.unix_times_ms`, `.cluster_sizes`).
- `Client.get_similarity_matches(...)` — return the top similarity matches as a `DataFrame[data_id, item_name, similarity]`.
- `Client.get_rheed_timeseries(...)` — fetch RHEED features with optional low-level features flattened into columns, plus point filters.
- `Client.get_frame(...)` — fetch a single extracted RHEED frame as a `RHEEDImageResult`.
- Fix: guard the missing-mask case so `client.get(video_id)` snapshots no longer error when a frame has no segmentation mask.
- Tidy customer-facing result docstrings (accuracy and clarity).
