### PR TITLE
Collapse duplicate time vals smartly

### DIFF
--- a/src/atomscale/timeseries/provider.py
+++ b/src/atomscale/timeseries/provider.py
@@ -129,8 +129,14 @@ def properties_payload_to_dataframe(
         # Real instrument logs occasionally emit a repeated timestamp for a
         # channel. A duplicate-labeled index cannot be reindexed, which would
         # break the axis=1 concat below, so collapse duplicates (last wins).
+        # Keep ts_ms/kept_rel aligned to the deduped series so the "longest"
+        # election below counts unique points and np.interp gets a non-repeating
+        # x-axis.
         if series.index.has_duplicates:
-            series = series[~series.index.duplicated(keep="last")]
+            mask = ~series.index.duplicated(keep="last")
+            series = series[mask]
+            kept_rel = [r for r, m in zip(kept_rel, mask) if m]
+            ts_ms = np.asarray(series.index, dtype=np.int64)
         series_by_name[name] = series
 
         if len(ts_ms) > longest_len:

--- a/src/atomscale/timeseries/provider.py
+++ b/src/atomscale/timeseries/provider.py
@@ -135,7 +135,7 @@ def properties_payload_to_dataframe(
         if series.index.has_duplicates:
             mask = ~series.index.duplicated(keep="last")
             series = series[mask]
-            kept_rel = [r for r, m in zip(kept_rel, mask) if m]
+            kept_rel = [r for r, m in zip(kept_rel, mask, strict=False) if m]
             ts_ms = np.asarray(series.index, dtype=np.int64)
         series_by_name[name] = series
 

--- a/src/atomscale/timeseries/provider.py
+++ b/src/atomscale/timeseries/provider.py
@@ -125,7 +125,13 @@ def properties_payload_to_dataframe(
 
         ts_ms = _to_int64_ms(kept_ts)
         # Stable order is enforced by the merged index sort below.
-        series_by_name[name] = pd.Series(kept_values, index=ts_ms, name=name)
+        series = pd.Series(kept_values, index=ts_ms, name=name)
+        # Real instrument logs occasionally emit a repeated timestamp for a
+        # channel. A duplicate-labeled index cannot be reindexed, which would
+        # break the axis=1 concat below, so collapse duplicates (last wins).
+        if series.index.has_duplicates:
+            series = series[~series.index.duplicated(keep="last")]
+        series_by_name[name] = series
 
         if len(ts_ms) > longest_len:
             longest_len = len(ts_ms)


### PR DESCRIPTION
Real instrument logs occasionally emit a repeated timestamp for the same channel. A duplicate-labeled pandas index can't be reindexed, which broke the axis=1 concat in properties_payload_to_dataframe. This collapses per-series duplicate timestamps before the concat (last value wins), so a repeated timestamp no longer errors out frame construction.